### PR TITLE
feat(visite-fce): Population de la colonne `visite_fce`

### DIFF
--- a/import-fce-test.sh
+++ b/import-fce-test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Test de import-fce.sh
+#
+# Usage:
+# 1. $ docker run --name sf-postgres -P -p 127.0.0.1:5432:5432 -e POSTGRES_PASSWORD=mysecretpassword -d postgres:10
+# 2. $ docker cp import-fce.sh sf-postgres:/
+# 3. $ docker cp import-fce-test.sh sf-postgres:/
+# 4. $ docker exec -it sf-postgres /import-fce-test.sh
+
+set -e # stop on any failure
+
+trap "[ -f fce-download.csv ] && rm fce-download.csv" EXIT
+
+if [ ! -f fce-download.csv.bak ]; then
+  cp fce-download.csv fce-download.csv.bak || true
+fi
+
+echo ""
+echo "👻 Création de données de tests ..."
+
+cat >fce-download.csv << CONTENT
+siret
+12345678901234
+12345678901236
+CONTENT
+
+psql -U "${DB_USER:-postgres}" << COMMANDS
+DROP DATABASE IF EXISTS datapi_test;
+CREATE DATABASE datapi_test;
+\connect datapi_test
+DROP DATABASE IF EXISTS etablissement;
+CREATE TABLE etablissement (siret VARCHAR(14), visite_fce BOOLEAN);
+INSERT INTO etablissement (siret) VALUES ('12345678901234');
+INSERT INTO etablissement (siret, visite_fce) VALUES ('12345678901235', true);
+INSERT INTO etablissement (siret, visite_fce) VALUES ('12345678901236', false);
+COMMANDS
+
+RESULTS=$(psql -U "${DB_USER:-postgres}" "datapi_test" -c "SELECT visite_fce, count(*) FROM etablissement GROUP BY visite_fce;")
+echo "${RESULTS}" | grep --quiet " f          |     1" # test will fail if count does not match
+echo "${RESULTS}" | grep --quiet " t          |     1" # test will fail if count does not match
+echo "${RESULTS}" | grep --quiet "            |     1" # test will fail if count does not match
+echo "${RESULTS}" | grep --quiet "(3 rows)"            # test will fail if count does not match
+
+DB_USER="${DB_USER:-postgres}" DB_NAME="datapi_test" ./import-fce.sh
+
+RESULTS=$(psql -U "${DB_USER:-postgres}" "datapi_test" -c "SELECT visite_fce, count(*) FROM etablissement GROUP BY visite_fce;")
+echo "${RESULTS}" | grep --quiet " f          |     1" # test will fail if count does not match
+echo "${RESULTS}" | grep --quiet " t          |     2" # test will fail if count does not match
+echo "${RESULTS}" | grep --quiet "(2 rows)"            # test will fail if count does not match
+
+echo "✅ import-fce.sh fonctionne comme prévu"

--- a/import-fce.sh
+++ b/import-fce.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Met à jour la colonne `visite_fce` de la table `etablissement`, en fonction
+# de la liste de SIRETs d'établissements ayant fait l'objet d'une visite,
+# fournie par l'API de FCE.
+#
+# Test: import-fce-test.sh
+
+set -e # stop on any failure
+
+trap "rm fce-download.csv" EXIT
+
+if [ ! -f fce-download.csv ]; then
+  echo ""
+  echo "🌍 Téléchargement des visites ..."
+  curl \
+    -H "Authorization: Apikey ${FCE_API_KEY}" \
+    -G https://dgefp.opendatasoft.com/api/records/1.0/download/ \
+    --data-urlencode "dataset=fce-visites" >fce-download.csv
+fi
+
+echo ""
+echo "🚚 Importation temporaire des SIRETs de fce-download.csv dans la base de données ..."
+cat fce-download.csv | PGPASSWORD="${DB_PASSWORD}" psql -U "${DB_USER}" "${DB_NAME:-datapi}" -c "CREATE TABLE tmp_fce_sirets (siret VARCHAR(14)); COPY tmp_fce_sirets FROM stdin WITH (FORMAT csv);"
+
+echo ""
+echo "📬 Mise à jour du champ visite_fce des etablissements ..."
+PGPASSWORD="${DB_PASSWORD}" psql -U "${DB_USER}" "${DB_NAME:-datapi}" << COMMANDS
+  UPDATE etablissement SET visite_fce = EXISTS(
+    SELECT siret FROM tmp_fce_sirets WHERE siret=etablissement.siret
+  );
+  DROP TABLE tmp_fce_sirets;
+  SELECT visite_fce, count(*) FROM etablissement GROUP BY visite_fce;
+COMMANDS


### PR DESCRIPTION
Script pour datapi v2 qui met à jour la colonne `visite_fce` de la table `etablissement`, en fonction de la liste de SIRETs d'établissements ayant fait l'objet d'une visite, fournie par l'API de FCE.

## Comment tester sur une bdd séparée (via Docker)

```sh
$ docker run --name sf-postgres -P -p 127.0.0.1:5432:5432 -e POSTGRES_PASSWORD=mysecretpassword -d postgres:10
$ docker cp import-fce.sh sf-postgres:/
$ docker cp import-fce-test.sh sf-postgres:/
$ docker exec -it sf-postgres /import-fce-test.sh
```

## Notes

Je n'ai pas testé sur les données de production.