### PR TITLE
Feat/datapi v2 fonctionnalité suivi d'entreprise

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -13,6 +13,7 @@ keycloakRealm = "master"
 
 # enableKeycloak = false
 # keycloakClient = "signauxfaibles"
+# fakeUserIDKeycloak = "john.doe@zone51.gov"
 # fakeKeycloakRole = [
 #   "Bourgogne-Franche-Comté",
 #   "urssaf",

--- a/follow.go
+++ b/follow.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	pgx "github.com/jackc/pgx/v4"
+)
+
+// Follow type follow pour l'API
+type Follow struct {
+	Siret                *string               `json:"siret"`
+	UserID               *string               `json:"userID"`
+	Active               bool                  `json:"active"`
+	Since                time.Time             `json:"since"`
+	Comment              string                `json:"comment"`
+	EtablissementSummary *EtablissementSummary `json:"etablissementSummary,omitempty"`
+}
+
+func (f *Follow) load(db *pgx.Conn) error {
+	sqlFollow := `select 
+		active, since, comment		
+		from etablissement_follow 
+		where
+		user_id = $1 and
+		siret = $2 and
+		active`
+
+	return db.QueryRow(context.Background(), sqlFollow, f.UserID, f.Siret).Scan(&f.Active, &f.Since, &f.Comment)
+}
+
+func (f *Follow) activate(d *pgx.Conn) error {
+	f.Active = true
+	sqlActivate := `insert into etablissement_follow
+	(siret, siren, user_id, active, since, comment)
+	select $1, $2, $3, true, current_timestamp, $4
+	from etablissement0 e
+	where siret = $5
+	returning since, true`
+
+	return db.QueryRow(context.Background(),
+		sqlActivate,
+		*f.Siret,
+		(*f.Siret)[0:9],
+		f.UserID,
+		f.Comment,
+		f.Siret,
+	).Scan(&f.Since, &f.Active)
+}
+
+func (f *Follow) deactivate() Jerror {
+	sqlUnactivate := `update etablissement_follow set active = false, until = current_timestamp
+		where siret = $1 and user_id = $2 and active = true`
+
+	commandTag, err := db.Exec(context.Background(),
+		sqlUnactivate, f.Siret, f.UserID)
+
+	if err != nil {
+		return errorToJSON(500, err)
+	}
+
+	if commandTag.RowsAffected() == 0 {
+		return newJSONerror(403, "this establishment is already not followed")
+	}
+
+	return nil
+}
+
+func (f *Follow) list() ([]Follow, Jerror) {
+	sqlFollow := `select f.siret, f.user_id, f.since, f.comment,
+	d.libelle, d.code, en.raison_sociale, e.commune,
+	r.libelle, e.ape, n.code_n1, n.libelle_n5, n.libelle_n1, ef.effectif
+	from etablissement_follow f
+	inner join etablissement0 e on e.siret = f.siret
+	inner join departements d on d.code = e.departement
+	inner join regions r on r.id = d.id_region
+	inner join entreprise0 en on en.siren = f.siren
+	inner join v_naf n on e.ape = n.code_n5
+	left join v_last_effectif ef on ef.siret = f.siret
+	where ((f.siret = $1 or $1 is null) and (f.user_id = $2 or $2 is null)) and f.active`
+
+	rows, err := db.Query(context.Background(), sqlFollow, f.Siret, f.UserID)
+	if err != nil {
+		return nil, errorToJSON(500, err)
+	}
+
+	var follows []Follow
+	for rows.Next() {
+		var f Follow
+		var e EtablissementSummary
+		err := rows.Scan(
+			&f.Siret, &f.UserID, &f.Since, &f.Comment,
+			&e.LibelleDepartement, &e.Departement, &e.RaisonSociale, &e.Commune,
+			&e.Region, &e.CodeActivite, &e.CodeSecteur, &e.Activite, &e.Secteur, &e.DernierEffectif,
+		)
+		if err != nil {
+			return nil, errorToJSON(500, err)
+		}
+		f.EtablissementSummary = &e
+		follows = append(follows, f)
+	}
+
+	return follows, nil
+}

--- a/handlers.go
+++ b/handlers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log"
 	"regexp"
 
@@ -10,21 +11,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-func getAllEntreprises(c *gin.Context) {
-	// log.Println("getAllEntreprises")
-	// db := c.MustGet("DB").(*sql.DB)
-	// entreprises, err := findAllEntreprises(db)
-	// if err != nil {
-	// 	c.JSON(500, err.Error())
-	// }
-	// c.JSON(200, entreprises)
-}
-
 func getEntreprise(c *gin.Context) {
 	roles := scopeFromContext(c)
 	siren := c.Param("siren")
-	isValidSiret, err := regexp.MatchString("[0-9]{9}", siren)
-	if !isValidSiret || err != nil {
+	if !isValidSiren(siren) {
 		c.JSON(400, "SIREN valide obligatoire")
 		return
 	}
@@ -45,34 +35,22 @@ func getEntreprise(c *gin.Context) {
 		c.JSON(404, "ressource non disponible")
 		return
 	}
-
 	for _, v := range etablissements.Etablissements {
 		entreprise.Etablissements = append(entreprise.Etablissements, v)
 	}
-
 	c.JSON(200, entreprise)
-}
-
-func getAllEtablissements(c *gin.Context) {
-	log.Println("getAllEtablissements")
-	db := c.MustGet("DB").(*sql.DB)
-	etablissements, err := findAllEtablissements(db)
-	if err != nil {
-		c.JSON(500, err.Error())
-	}
-	c.JSON(200, etablissements)
 }
 
 func getEtablissement(c *gin.Context) {
 	roles := scopeFromContext(c)
 	siret := c.Param("siret")
-	isValidSiret, err := regexp.MatchString("[0-9]{14}", siret)
-	if !isValidSiret || err != nil {
+	if !isValidSiret(siret) {
 		c.JSON(400, "SIRET valide obligatoire")
+		return
 	}
 	var etablissements Etablissements
 	etablissements.Query.Sirets = []string{siret}
-	err = etablissements.load(roles)
+	err := etablissements.load(roles)
 
 	result, ok := etablissements.Etablissements[siret]
 	if !ok {
@@ -92,14 +70,13 @@ func getEtablissement(c *gin.Context) {
 func getEntrepriseEtablissements(c *gin.Context) {
 	roles := scopeFromContext(c)
 	siren := c.Param("siren")
-	isValidSiret, err := regexp.MatchString("[0-9]{9}", siren)
-	if !isValidSiret || err != nil {
+	if !isValidSiren(siren) {
 		c.JSON(400, "SIREN valide obligatoire")
 		return
 	}
 	var etablissements Etablissements
 	etablissements.Query.Sirens = []string{siren}
-	err = etablissements.load(roles)
+	err := etablissements.load(roles)
 	if err != nil {
 		c.JSON(500, err.Error())
 		return
@@ -129,10 +106,9 @@ func getEntreprisesFollowedByUser(c *gin.Context) {
 	c.JSON(200, entreprises)
 }
 
-func followEntreprise(c *gin.Context) {
-	// log.Println("followEntreprise")
-	// db := c.MustGet("DB").(*sql.DB)
-	// siren := c.Param("siren")
+func followEtablissement(c *gin.Context) {
+	siren := c.Param("siren")
+	fmt.Println(siren)
 	// // TODO: valider SIREN
 	// if siren == "" {
 	// 	c.JSON(400, "SIREN obligatoire")
@@ -151,7 +127,6 @@ func getEntrepriseComments(c *gin.Context) {
 	log.Println("getEntreprisesComments")
 	db := c.MustGet("DB").(*sql.DB)
 	siren := c.Param("siren")
-	// TODO: valider SIREN
 	if siren == "" {
 		c.JSON(400, "SIREN obligatoire")
 		return
@@ -168,9 +143,8 @@ func addEntrepriseComment(c *gin.Context) {
 	log.Println("addEntrepriseComment")
 	db := c.MustGet("DB").(*sql.DB)
 	siren := c.Param("siren")
-	// TODO: valider SIREN
-	if siren == "" {
-		c.JSON(400, "SIREN obligatoire")
+	if !isValidSiren(siren) {
+		c.JSON(400, "SIREN valide obligatoire")
 		return
 	}
 	message := c.Param("message")
@@ -368,4 +342,20 @@ func importHandler(c *gin.Context) {
 		c.AbortWithError(500, err)
 		return
 	}
+}
+
+func isValidSiren(siren string) bool {
+	match, err := regexp.MatchString("[0-9]{9}", siren)
+	if err != nil {
+		return false
+	}
+	return match
+}
+
+func isValidSiret(siret string) bool {
+	match, err := regexp.MatchString("[0-9]{14}", siret)
+	if err != nil {
+		return false
+	}
+	return match
 }

--- a/handlers.go
+++ b/handlers.go
@@ -14,10 +14,6 @@ import (
 func getEntreprise(c *gin.Context) {
 	roles := scopeFromContext(c)
 	siren := c.Param("siren")
-	if !isValidSiren(siren) {
-		c.JSON(400, "SIREN valide obligatoire")
-		return
-	}
 	siret, err := getSiegeFromSiren(siren)
 	if err != nil {
 		c.JSON(500, err.Error())
@@ -44,10 +40,6 @@ func getEntreprise(c *gin.Context) {
 func getEtablissement(c *gin.Context) {
 	roles := scopeFromContext(c)
 	siret := c.Param("siret")
-	if !isValidSiret(siret) {
-		c.JSON(400, "SIRET valide obligatoire")
-		return
-	}
 	var etablissements Etablissements
 	etablissements.Query.Sirets = []string{siret}
 	err := etablissements.load(roles)
@@ -70,10 +62,6 @@ func getEtablissement(c *gin.Context) {
 func getEntrepriseEtablissements(c *gin.Context) {
 	roles := scopeFromContext(c)
 	siren := c.Param("siren")
-	if !isValidSiren(siren) {
-		c.JSON(400, "SIREN valide obligatoire")
-		return
-	}
 	var etablissements Etablissements
 	etablissements.Query.Sirens = []string{siren}
 	err := etablissements.load(roles)
@@ -143,10 +131,6 @@ func addEntrepriseComment(c *gin.Context) {
 	log.Println("addEntrepriseComment")
 	db := c.MustGet("DB").(*sql.DB)
 	siren := c.Param("siren")
-	if !isValidSiren(siren) {
-		c.JSON(400, "SIREN valide obligatoire")
-		return
-	}
 	message := c.Param("message")
 	if message == "" {
 		c.JSON(400, "Message obligatoire")
@@ -344,18 +328,20 @@ func importHandler(c *gin.Context) {
 	}
 }
 
-func isValidSiren(siren string) bool {
+func validSiren(c *gin.Context) {
+	siren := c.Param("siren")
 	match, err := regexp.MatchString("[0-9]{9}", siren)
-	if err != nil {
-		return false
+	if err != nil || !match {
+		c.AbortWithStatusJSON(400, "SIREN valide obligatoire")
 	}
-	return match
+	c.Next()
 }
 
-func isValidSiret(siret string) bool {
-	match, err := regexp.MatchString("[0-9]{14}", siret)
-	if err != nil {
-		return false
+func validSiret(c *gin.Context) {
+	siren := c.Param("siret")
+	match, err := regexp.MatchString("[0-9]{14}", siren)
+	if err != nil || !match {
+		c.AbortWithStatusJSON(400, "SIRET valide obligatoire")
 	}
-	return match
+	c.Next()
 }

--- a/import.go
+++ b/import.go
@@ -33,11 +33,9 @@ func processEntreprise(fileName string, tx *pgx.Tx) error {
 		return err
 	}
 	defer file.Close()
-
 	batches, wg := newBatchRunner(tx)
 	unzip, err := gzip.NewReader(file)
 	decoder := json.NewDecoder(unzip)
-
 	i := 0
 	for {
 		var e entreprise
@@ -51,7 +49,6 @@ func processEntreprise(fileName string, tx *pgx.Tx) error {
 			}
 			return err
 		}
-
 		if e.Value.SireneUL.Siren != "" {
 			batch := e.getBatch()
 			batches <- batch
@@ -61,7 +58,6 @@ func processEntreprise(fileName string, tx *pgx.Tx) error {
 			}
 		}
 	}
-
 }
 
 func processEtablissement(fileName string, tx *pgx.Tx) error {
@@ -74,7 +70,6 @@ func processEtablissement(fileName string, tx *pgx.Tx) error {
 	if err != nil {
 		return err
 	}
-
 	batches, wg := newBatchRunner(tx)
 	unzip, err := gzip.NewReader(file)
 	decoder := json.NewDecoder(unzip)

--- a/keycloak.go
+++ b/keycloak.go
@@ -50,7 +50,14 @@ func keycloakMiddleware(c *gin.Context) {
 		return
 	}
 
+	if email, ok := (*claims)["email"]; ok {
+		c.Set("userID", email)
+	} else {
+		c.AbortWithStatus(401)
+	}
+
 	c.Set("claims", claims)
+
 	c.Next()
 }
 
@@ -68,6 +75,7 @@ func fakeCloakMiddleware(c *gin.Context) {
 		},
 	}
 
+	c.Set("userID", viper.GetString("fakeUserIDKeycloak"))
 	c.Set("claims", &claims)
 	c.Next()
 }

--- a/main.go
+++ b/main.go
@@ -40,10 +40,10 @@ func runAPI() {
 	config := cors.DefaultConfig()
 	config.AllowOrigins = []string{"*"}
 	config.AddAllowHeaders("Authorization")
-	config.AddAllowMethods("GET", "POST")
+	config.AddAllowMethods("GET", "POST", "DELETE")
 	router.Use(cors.New(config))
 
-	router.Use(dbMiddleware(db))
+	// router.Use(dbMiddleware(db))
 
 	if viper.GetBool("enableKeycloak") {
 		router.Use(keycloakMiddleware)
@@ -55,8 +55,9 @@ func runAPI() {
 	router.GET("/etablissement/get/:siret", validSiret, getEtablissement)
 	router.GET("/etablissements/get/:siren", validSiren, getEntrepriseEtablissements)
 
-	router.GET("/follow", getEntreprisesFollowedByUser)
+	router.GET("/follow", getEtablissementsFollowedByCurrentUser)
 	router.POST("/follow/:siret", validSiret, followEtablissement)
+	router.DELETE("/follow/:siret", validSiret, unfollowEtablissement)
 
 	router.GET("/entreprise/comments/:siren", validSiren, getEntrepriseComments)
 	router.POST("/entreprise/comments/:siren", validSiren, addEntrepriseComment)
@@ -78,9 +79,9 @@ func runAPI() {
 	}
 }
 
-func dbMiddleware(db *pgx.Conn) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		c.Set("DB", db)
-		c.Next()
-	}
-}
+// func dbMiddleware(db *pgx.Conn) gin.HandlerFunc {
+// 	return func(c *gin.Context) {
+// 		c.Set("DB", db)
+// 		c.Next()
+// 	}
+// }

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func runAPI() {
 	router.GET("/etablissements/get/:siren", getEntrepriseEtablissements)
 
 	router.GET("/follow", getEntreprisesFollowedByUser)
-	router.POST("/follow/:siren", followEntreprise)
+	router.POST("/follow/:siret", followEtablissement)
 
 	router.GET("/entreprise/comments/:siren", getEntrepriseComments)
 	router.POST("/entreprise/comments/:siren", addEntrepriseComment)

--- a/main.go
+++ b/main.go
@@ -51,15 +51,15 @@ func runAPI() {
 		router.Use(fakeCloakMiddleware)
 	}
 
-	router.GET("/entreprise/get/:siren", getEntreprise)
-	router.GET("/etablissement/get/:siret", getEtablissement)
-	router.GET("/etablissements/get/:siren", getEntrepriseEtablissements)
+	router.GET("/entreprise/get/:siren", validSiren, getEntreprise)
+	router.GET("/etablissement/get/:siret", validSiret, getEtablissement)
+	router.GET("/etablissements/get/:siren", validSiren, getEntrepriseEtablissements)
 
 	router.GET("/follow", getEntreprisesFollowedByUser)
-	router.POST("/follow/:siret", followEtablissement)
+	router.POST("/follow/:siret", validSiret, followEtablissement)
 
-	router.GET("/entreprise/comments/:siren", getEntrepriseComments)
-	router.POST("/entreprise/comments/:siren", addEntrepriseComment)
+	router.GET("/entreprise/comments/:siren", validSiren, getEntrepriseComments)
+	router.POST("/entreprise/comments/:siren", validSiren, addEntrepriseComment)
 
 	router.GET("/listes", getListes)
 	router.POST("/scores", getLastListeScores)

--- a/migrations/200803_1_create_entreprise.sql
+++ b/migrations/200803_1_create_entreprise.sql
@@ -1,7 +1,7 @@
 create sequence entreprise_id;
 create table entreprise (
   id integer primary key default nextval('entreprise_id'),
-  siren char(9),
+  siren varchar(9),
   version integer default 0,
   date_add timestamp default current_timestamp,
   siret_siege char(14),
@@ -13,7 +13,7 @@ create table entreprise (
 create sequence entreprise_bdf_id;
 create table entreprise_bdf (
   id integer primary key default nextval('entreprise_bdf_id'),
-  siren text,
+  siren varchar(9),
   version integer default 0,
   date_add timestamp default current_timestamp,
   arrete_bilan_bdf date,
@@ -30,7 +30,7 @@ create table entreprise_bdf (
 create sequence entreprise_diane_id;
 create table entreprise_diane (
   id integer primary key default nextval('entreprise_diane_id'),
-  siren text,
+  siren varchar(9),
   version integer default 0,
   date_add timestamp default current_timestamp,
   arrete_bilan_diane date,
@@ -108,26 +108,10 @@ create table entreprise_diane (
   hash text
 );
 
-create table entreprise_followers (
-  id integer primary key,
-  siren varchar(14),
-  id_keycloak text,
-  date_add timestamp,
-  status text,
-  data jsonb
-);
-
-create table entreprise_scope (
-  id integer primary key,
-  id_entreprise int references entreprise (id),
-  siren varchar(9),
-  scope text[]
-);
-
 create table entreprise_comments (
   id int primary key,
   id_parent int references entreprise_comments,
-  siren text,
+  siren varchar(9),
   id_keycloak text,
   date_add timestamp,
   comment text

--- a/migrations/200803_2_create_etablissement.sql
+++ b/migrations/200803_2_create_etablissement.sql
@@ -2,9 +2,9 @@ create sequence etablissement_id;
 create table etablissement (
   id               integer primary key default nextval('etablissement_id'),
   siret            varchar(14),
+  siren            varchar(9),
   version          integer default 0,
   date_add         timestamp default current_timestamp,
-  siren            char(9),
   adresse          text,
   ape              text,
   code_postal      text,
@@ -109,4 +109,16 @@ create table etablissement_procol (
   action_procol text,
   stade_procol  text,
   hash          text
+);
+
+create sequence etablissemment_follow_id;
+create table etablissement_follow (
+  id integer primary key default nextval('etablissemment_follow_id'),
+  siret varchar(14),
+  siren varchar(9),
+  user_id text,
+  active boolean,
+  since timestamp,
+  until timestamp,
+  comment text  
 );

--- a/migrations/200825_0_indexes.sql
+++ b/migrations/200825_0_indexes.sql
@@ -15,3 +15,4 @@ create index idx_liste_libelle on liste (libelle) where version = 0;
 create index idx_etablissement_procol on etablissement_procol (siret) where version = 0;
 create index idx_etablissement_delai on etablissement_delai (siret) where version = 0;
 create index idx_naf_code_niveau on naf (code, niveau);
+create index idx_etablissement_follow on etablissement_follow (siret, user_id);

--- a/models.go
+++ b/models.go
@@ -24,11 +24,17 @@ type Entreprise struct {
 
 // EtablissementSummary …
 type EtablissementSummary struct {
-	Siret          string `json:"siret"`
-	Departement    string `json:"departement"`
-	Region         string `json:"region"`
-	CodeActivite   string `json:"codeActivite"`
-	CodeActiviteN1 string ``
+	Siret              *string `json:"siret,omitempty"`
+	Departement        *string `json:"departement"`
+	LibelleDepartement *string `json:"libelleDepartement"`
+	RaisonSociale      *string `json:"raisonSociale"`
+	Commune            *string `json:"commune"`
+	Region             *string `json:"region"`
+	CodeActivite       *string `json:"codeActivite"`
+	CodeSecteur        *string `json:"codeSecteur"`
+	Activite           *string `json:"activite"`
+	Secteur            *string `json:"secteur"`
+	DernierEffectif    *int    `json:"dernierEffectif,omitempty"`
 }
 
 type findEtablissementsParams struct {
@@ -62,7 +68,7 @@ type Etablissement struct {
 		Longitude  float64 `json:"longitude"`
 		NumeroVoie string  `json:"numeroVoie"`
 		TypeVoie   string  `json:"typeVoie"`
-		Commune    string  `json:"string"`
+		Commune    string  `json:"commune"`
 		NAF        struct {
 			APE     string `json:"activite"`
 			Secteur string `json:"secteur"`
@@ -148,14 +154,6 @@ type EtablissementScore struct {
 	Score   float64   `json:"score"`
 	Diff    float64   `json:"diff"`
 	Alert   string    `json:"alert"`
-}
-
-// Follow type follow pour l'API
-type Follow struct {
-	Siret  string `json:"siren"`
-	UserID string `json:"userId"`
-	Query  struct {
-	}
 }
 
 // Comment commentaire sur une enterprise
@@ -815,4 +813,35 @@ func getSiegeFromSiren(siren string) (string, error) {
 	var siret string
 	err := db.QueryRow(context.Background(), sqlSiege, siren).Scan(&siret)
 	return siret, err
+}
+
+// Jerror interface for JSON errors
+type Jerror interface {
+	Error() string
+	Code() int
+}
+
+// JSONerror enables returning enriched errors with JSON status
+type JSONerror struct {
+	error string
+	code  int
+}
+
+// Error() provide the classical error status
+func (j JSONerror) Error() string {
+	return j.error
+}
+
+// Code provides JSON error code to be returned
+func (j JSONerror) Code() int {
+	return j.code
+}
+
+// newJSONerror return JSON error from string
+func newJSONerror(code int, e string) JSONerror {
+	return JSONerror{error: e, code: code}
+}
+
+func errorToJSON(code int, e error) JSONerror {
+	return JSONerror{error: e.Error(), code: code}
 }


### PR DESCRIPTION
3 nouveaux points d'entrée disponibles sur l'API:

```
GET        /follow             retourne les etablissements suivi par l'utilisateur connecté
```
Retourne la liste avec un code 200.


```
POST      /follow/:siret    enregistre le suivi d'un établissement
```
Retourne les informations enregistrées avec un code 201 (created).
Dans le cas où le suivi est déjà actif, retour des informations préalablement enregistrées avec un code 204 (no content).
Dans le cas où l'établissement n'existe pas, retour 403 (forbidden).


```
DELETE  /follow/:siret    stope le suivi d'un établissement
```
La date de suivi et d'arrêt est enregistré (ainsi bien sûr que le commentaire).
Si l'établissement n'était pas suivi ou n'existe pas (et n'est donc pas suivi), retour 204.



Bonus: 
- 2 middlewares pour valider siret et siren avant d'entrer dans le handler
- ajout du `userID` dans le context gin.