### PR TITLE
Feat/datapiv2 optimisation hashing et versionning

### DIFF
--- a/entreprise.go
+++ b/entreprise.go
@@ -258,7 +258,7 @@ func (e *Etablissements) getBatch(roles scope) *pgx.Batch {
 		inner join departements d on d.code = et.departement
 		inner join regions r on d.id_region = r.id
 		left join entreprise0 en on en.siren = et.siren
-	where 
+		where 
 		(et.siret=any($1) or et.siren=any($2))
 		and coalesce($1, $2) is not null
 	`, e.Query.Sirets, e.Query.Sirens, roles.zoneGeo())

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/appleboy/gin-jwt v2.5.0+incompatible
 	github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6 // indirect
+	github.com/cnf/structhash v0.0.0-20180104161610-62a607eb0224
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cnf/structhash v0.0.0-20180104161610-62a607eb0224 h1:rnCKRrdSBqc061l0CDuYB+7X3w6w8IK/VCSChJXv62g=
+github.com/cnf/structhash v0.0.0-20180104161610-62a607eb0224/go.mod h1:pCxVEbcm3AMg7ejXyorUXi6HQCzOIBf7zEDVPtw0/U4=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/migrations/200825_0_indexes.sql
+++ b/migrations/200825_0_indexes.sql
@@ -1,23 +1,40 @@
 create index idx_etablissement_siret on etablissement using hash (siret) where version = 0;
 create index idx_etablissement_siren on etablissement using hash (siren) where version = 0;
+create index idx_etablissement_departement on etablissement (departement) where version = 0;
+create index idx_etablissement_hash on etablissement (siret, hash) where version in (0, 1);
+create index idx_etablissement_naf on etablissement (ape) where version = 0;
+
 create index idx_entreprise_siren on entreprise using hash (siren) where version = 0;
+create index idx_entreprise_hash on entreprise (siren, hash) where version in (0, 1);
+
+create index idx_etablissement_procol_siret on etablissement_procol using hash (siret) where version = 0;
+create index idx_etablissement_procol_hash on etablissement_procol (siret, hash) where version in (0, 1);
+
+create index idx_etablissement_delai_siret on etablissement_delai using hash (siret) where version = 0;
+create index idx_etablissement_delai_hash on etablissement_delai (siret, hash) where version in (0, 1);
+
 create index idx_etablissement_periode_urssaf_siret on etablissement_periode_urssaf using hash (siret) where version = 0;
 create index idx_etablissement_periode_urssaf_siren on etablissement_periode_urssaf using hash (siren) where version = 0;
+create index idx_etablissement_periode_urssaf_hash on etablissement_periode_urssaf (siret, hash) where version in (0, 1);
+
 create index idx_etablissement_apconso_siret on etablissement_apconso using hash (siret) where version = 0;
 create index idx_etablissement_apconso_siren on etablissement_apconso using hash (siren) where version = 0;
+create index idx_etablissement_apconso_hash on etablissement_apconso (siret, hash) where version in (0, 1);
+
 create index idx_etablissement_apdemande_siret on etablissement_apdemande using hash (siret) where version = 0;
 create index idx_etablissement_apdemande_siren on etablissement_apdemande using hash (siren) where version = 0;
+create index idx_etablissement_apdemande_hash on etablissement_apdemande (siret, hash) where version in (0, 1);
+
 create index idx_score_siret on score using hash (siret) where version = 0;
 create index idx_score_siren on score using hash (siren) where version = 0;
 create index idx_score_alert on score using hash (alert) where version = 0;
 create index idx_score_liste on score using hash (libelle_liste) where version = 0;
-create index idx_liste_libelle on liste using hash (libelle) where version = 0;
-create index idx_etablissement_procol on etablissement_procol using hash (siret) where version = 0;
-create index idx_etablissement_delai on etablissement_delai using hash (siret) where version = 0;
-create index idx_naf_code_niveau on naf (code, niveau);
-create index idx_etablissement_follow on etablissement_follow (siret, user_id);
-create index idx_etablissement_departement on etablissement (departement) where version = 0;
 create index idx_score_score on score (score) where version = 0;
-create index idx_etablissement_naf on etablissement (ape) where version = 0;
+create index idx_score_hash on score (siret, hash) where version in (0, 1);
+
+create index idx_liste_libelle on liste using hash (libelle) where version = 0;
+create index idx_naf_code_niveau on naf (code, niveau);
+create index idx_etablissement_follow on etablissement_follow (siret, user_id, active);
+
 create index idx_naf_code on naf using hash (code);
 create index idx_naf_n1 on naf (id_n1);


### PR DESCRIPTION
Une modification qui divise le temps d'intégration par 3 sur ma machine.

Les hash md5 des données sont calculés avec la librairie structhash et insérés en même temps que les données métier.
Des indexes ont été ajoutés pour permettre une recherche rapide des doublons et l'écriture de la requête réadaptée pour en tirer partie.

Le temps d'insert des données a augmenté de 30% du fait du calcul du hash, le temps du versionning a lui par contre été divisé par 10.