### PR TITLE
Feat/datapiv2 utilisation de pools de connexion à la place d'une connexion unique

### DIFF
--- a/follow.go
+++ b/follow.go
@@ -3,8 +3,6 @@ package main
 import (
 	"context"
 	"time"
-
-	pgx "github.com/jackc/pgx/v4"
 )
 
 // Follow type follow pour l'API
@@ -17,7 +15,7 @@ type Follow struct {
 	EtablissementSummary *EtablissementSummary `json:"etablissementSummary,omitempty"`
 }
 
-func (f *Follow) load(db *pgx.Conn) error {
+func (f *Follow) load() error {
 	sqlFollow := `select 
 		active, since, comment		
 		from etablissement_follow 
@@ -29,7 +27,7 @@ func (f *Follow) load(db *pgx.Conn) error {
 	return db.QueryRow(context.Background(), sqlFollow, f.UserID, f.Siret).Scan(&f.Active, &f.Since, &f.Comment)
 }
 
-func (f *Follow) activate(d *pgx.Conn) error {
+func (f *Follow) activate() error {
 	f.Active = true
 	sqlActivate := `insert into etablissement_follow
 	(siret, siren, user_id, active, since, comment)

--- a/go.sum
+++ b/go.sum
@@ -254,6 +254,7 @@ github.com/jackc/pgx/v4 v4.8.1/go.mod h1:4HOLxrl8wToZJReD04/yB20GDwf4KBYETvlHciC
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle v1.1.1 h1:PJAw7H/9hoWC4Kf3J8iNmL1SwA6E8vfsLqBiL+F6CtI=
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/main.go
+++ b/main.go
@@ -7,13 +7,13 @@ import (
 	gocloak "github.com/Nerzal/gocloak/v6"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
-	pgx "github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
 
 	"github.com/spf13/viper"
 )
 
 var keycloak gocloak.GoCloak
-var db *pgx.Conn
+var db *pgxpool.Pool
 var ref reference
 
 func main() {

--- a/score.go
+++ b/score.go
@@ -84,7 +84,7 @@ func followEtablissement(c *gin.Context) {
 		Comment: param.Comment,
 	}
 
-	err = follow.load(db)
+	err = follow.load()
 	if err != nil && err.Error() != "no rows in result set" {
 		c.AbortWithError(500, err)
 		return
@@ -93,7 +93,7 @@ func followEtablissement(c *gin.Context) {
 	if follow.Active {
 		c.JSON(204, follow)
 	} else {
-		err := follow.activate(db)
+		err := follow.activate()
 		if err != nil && err.Error() != "no rows in result set" {
 			c.AbortWithError(500, err)
 			return


### PR DESCRIPTION
La librairie pgx propose un add-on permettant l'utilisation de pools de connexion en lieu et place d'une connexion unique.

Cet add-on conserve l'entièreté de l'API, ici il s'agit juste donc d'ajuster quelques types de variables (en particulier pour les fonctions qui initialisent la connexion à la base et la variable db qui est globale et passe donc du type `pgx.Conn` à pgxpool.Pool`.

Une mutation low-effort qui fait du bien au moral :)