### PR TITLE
feat / recherche d'entreprise

### DIFF
--- a/entreprise.go
+++ b/entreprise.go
@@ -741,18 +741,6 @@ func searchEtablissementHandler(c *gin.Context) {
 
 }
 
-// Siret              *string `json:"siret,omitempty"`
-// Departement        *string `json:"departement"`
-// LibelleDepartement *string `json:"libelleDepartement"`
-// RaisonSociale      *string `json:"raisonSociale"`
-// Commune            *string `json:"commune"`
-// Region             *string `json:"region"`
-// CodeActivite       *string `json:"codeActivite"`
-// CodeSecteur        *string `json:"codeSecteur"`
-// Activite           *string `json:"activite"`
-// Secteur            *string `json:"secteur"`
-// DernierEffectif    *int    `json:"dernierEffectif,omitempty"`
-
 type searchResult struct {
 	From                  int                    `json:"from"`
 	To                    int                    `json:"to"`
@@ -762,15 +750,6 @@ type searchResult struct {
 }
 
 func searchEtablissement(params searchParams) (searchResult, Jerror) {
-	/*
-		$1 search string
-		$2 search string
-		$3 result length
-		$4 result offset
-		$5 `departement` list from user
-		$6 `role` list from user
-	*/
-
 	sqlSearch := `select et.siret, d.libelle, d.code, en.raison_sociale, et.commune,
 	r.libelle, n.code_n1, n.libelle_n1, n.code_n5, n.libelle_n5, count(*) over ()
 	from etablissement0 et

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ func runAPI() {
 	etablissement.GET("/comments/:siret", validSiret, getEntrepriseComments)
 	etablissement.POST("/comments/:siret", validSiret, addEntrepriseComment)
 	etablissement.PUT("/comments/:id", updateEntrepriseComment)
+	etablissement.GET("/search/:search", searchEtablissementHandler)
 
 	follow := router.Group("/follow", getKeycloakMiddleware())
 	follow.GET("", getEtablissementsFollowedByCurrentUser)


### PR DESCRIPTION
# Recherche d'établissemment par siret ou raison sociale

Le service est disponible sur /etablissement/search/:siret_or_raisoc et propose quelques options utilisables en query string
Par défaut le service renverra les établissements qui sont dans la zone géographique de l'utilisateur.

Le paramètre `siret_or_raisoc` doit comporter au minimum 3 caractères.

Le service renvoie un résultat paginé en donnant des propriétés comme le nombre de pages du résultat (pageMax), le nombre d'établissements (total) et la plage de couverture du résultat (from et to). Pour obtenir les pages suivantes lors d'une recherche, il faut utiliser la paramètre `page` (int). Lorsque ce paramètre est absent, c'est la première page qui est servie.

Le paramètre `ignorezone` (booléen) permet d'ignorer cette restriction de zone géographique, l'utilisateur obtiendra alors également les établissements faisant partie d'entreprises ayant au moins un établissement dans sa zone géographique (et donc susceptible d'avoir des alertes qui lui sont visibles)

Le paramètre `ignoreroles` quant à lui permet d'ignorer cette deuxième restriction et d'avoir ainsi accès à tous les établissements disponibles dans signauxfaibles, bien que cela n'ouvre pas de droit particulier pour en consulter les informations soumises à autorisation.

Exemple de requête httpie: `http ':3000/etablissement/search/ETA?page=1&ignorezone=true'`