### PR TITLE
Feat/datapi v2 follow au format score

### DIFF
--- a/follow.go
+++ b/follow.go
@@ -10,12 +10,12 @@ import (
 
 // Follow type follow pour l'API
 type Follow struct {
-	Siret         *string   `json:"siret"`
-	Username      *string   `json:"username"`
-	Active        bool      `json:"active"`
-	Since         time.Time `json:"since"`
-	Comment       string    `json:"comment"`
-	Etablissement *Score    `json:"etablissement,omitempty"`
+	Siret          *string   `json:"siret,omitempty"`
+	Username       *string   `json:"username,omitempty"`
+	Active         bool      `json:"active"`
+	Since          time.Time `json:"since"`
+	Comment        string    `json:"comment"`
+	Etablissements *Score    `json:"etablissements,omitempty"`
 }
 
 func getEtablissementsFollowedByCurrentUser(c *gin.Context) {
@@ -189,7 +189,7 @@ func (f *Follow) list(roles scope) ([]Follow, Jerror) {
 	left join v_last_procol ep on ep.siret = f.siret
 	left join v_diane_variation_ca di on di.siren = f.siren
 	left join score s on s.siret = f.siret and s.libelle_liste = $2
-	where f.username = $3
+	where f.username = $3 and f.active
 	`
 
 	rows, err := db.Query(context.Background(), sqlFollow, roles, liste[0].ID, f.Username)
@@ -231,7 +231,7 @@ func (f *Follow) list(roles scope) ([]Follow, Jerror) {
 		if err != nil {
 			return nil, errorToJSON(500, err)
 		}
-		f.Etablissement = &e
+		f.Etablissements = &e
 		f.Active = true
 		follows = append(follows, f)
 	}

--- a/follow.go
+++ b/follow.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -9,103 +10,32 @@ import (
 
 // Follow type follow pour l'API
 type Follow struct {
-	Siret                *string               `json:"siret"`
-	Username             *string               `json:"username"`
-	Active               bool                  `json:"active"`
-	Since                time.Time             `json:"since"`
-	Comment              string                `json:"comment"`
-	EtablissementSummary *EtablissementSummary `json:"etablissementSummary,omitempty"`
+	Siret         *string   `json:"siret"`
+	Username      *string   `json:"username"`
+	Active        bool      `json:"active"`
+	Since         time.Time `json:"since"`
+	Comment       string    `json:"comment"`
+	Etablissement *Score    `json:"etablissement,omitempty"`
 }
 
-func (f *Follow) load() error {
-	sqlFollow := `select 
-		active, since, comment		
-		from etablissement_follow 
-		where
-		username = $1 and
-		siret = $2 and
-		active`
-
-	return db.QueryRow(context.Background(), sqlFollow, f.Username, f.Siret).Scan(&f.Active, &f.Since, &f.Comment)
-}
-
-func (f *Follow) activate() error {
-	f.Active = true
-	sqlActivate := `insert into etablissement_follow
-	(siret, siren, username, active, since, comment)
-	select $1, $2, $3, true, current_timestamp, $4
-	from etablissement0 e
-	where siret = $5
-	returning since, true`
-
-	return db.QueryRow(context.Background(),
-		sqlActivate,
-		*f.Siret,
-		(*f.Siret)[0:9],
-		f.Username,
-		f.Comment,
-		f.Siret,
-	).Scan(&f.Since, &f.Active)
-}
-
-func (f *Follow) deactivate() Jerror {
-	sqlUnactivate := `update etablissement_follow set active = false, until = current_timestamp
-		where siret = $1 and username = $2 and active = true`
-
-	commandTag, err := db.Exec(context.Background(),
-		sqlUnactivate, f.Siret, f.Username)
+func getEtablissementsFollowedByCurrentUser(c *gin.Context) {
+	username := c.GetString("username")
+	scope := scopeFromContext(c)
+	follow := Follow{Username: &username}
+	follows, err := follow.list(scope)
 
 	if err != nil {
-		return errorToJSON(500, err)
+		c.JSON(err.Code(), err.Error())
+		return
 	}
 
-	if commandTag.RowsAffected() == 0 {
-		return newJSONerror(204, "this establishment is already not followed")
-	}
-
-	return nil
-}
-
-func (f *Follow) list() ([]Follow, Jerror) {
-	sqlFollow := `select f.siret, f.username, f.since, f.comment,
-	d.libelle, d.code, en.raison_sociale, e.commune,
-	r.libelle, e.ape, n.code_n1, n.libelle_n5, n.libelle_n1, ef.effectif
-	from etablissement_follow f
-	inner join etablissement0 e on e.siret = f.siret
-	inner join departements d on d.code = e.departement
-	inner join regions r on r.id = d.id_region
-	inner join entreprise0 en on en.siren = f.siren
-	inner join v_naf n on e.ape = n.code_n5
-	left join v_last_effectif ef on ef.siret = f.siret
-	where ((f.siret = $1 or $1 is null) and (f.username = $2 or $2 is null)) and f.active`
-
-	rows, err := db.Query(context.Background(), sqlFollow, f.Siret, f.Username)
-	if err != nil {
-		return nil, errorToJSON(500, err)
-	}
-
-	var follows []Follow
-	for rows.Next() {
-		var f Follow
-		var e EtablissementSummary
-		err := rows.Scan(
-			&f.Siret, &f.Username, &f.Since, &f.Comment,
-			&e.LibelleDepartement, &e.Departement, &e.RaisonSociale, &e.Commune,
-			&e.Region, &e.CodeActivite, &e.CodeSecteur, &e.Activite, &e.Secteur, &e.DernierEffectif,
-		)
-		if err != nil {
-			return nil, errorToJSON(500, err)
-		}
-		f.EtablissementSummary = &e
-		follows = append(follows, f)
-	}
-
-	return follows, nil
+	c.JSON(200, follows)
 }
 
 func followEtablissement(c *gin.Context) {
 	siret := c.Param("siret")
 	username := c.GetString("username")
+
 	var param struct {
 		Comment string `json:"comment"`
 	}
@@ -160,4 +90,145 @@ func unfollowEtablissement(c *gin.Context) {
 		return
 	}
 	c.JSON(200, "this establishment is no longer followed")
+}
+
+func (f *Follow) load() error {
+	sqlFollow := `select 
+		active, since, comment		
+		from etablissement_follow 
+		where
+		username = $1 and
+		siret = $2 and
+		active`
+
+	return db.QueryRow(context.Background(), sqlFollow, f.Username, f.Siret).Scan(&f.Active, &f.Since, &f.Comment)
+}
+
+func (f *Follow) activate() error {
+	f.Active = true
+	fmt.Println("coucou")
+	sqlActivate := `insert into etablissement_follow
+	(siret, siren, username, active, since, comment)
+	select $1, $2, $3, true, current_timestamp, $4
+	from etablissement0 e
+	where siret = $5
+	returning since, true`
+
+	return db.QueryRow(context.Background(),
+		sqlActivate,
+		*f.Siret,
+		(*f.Siret)[0:9],
+		f.Username,
+		f.Comment,
+		f.Siret,
+	).Scan(&f.Since, &f.Active)
+}
+
+func (f *Follow) deactivate() Jerror {
+	sqlUnactivate := `update etablissement_follow set active = false, until = current_timestamp
+		where siret = $1 and username = $2 and active = true`
+
+	commandTag, err := db.Exec(context.Background(),
+		sqlUnactivate, f.Siret, f.Username)
+
+	if err != nil {
+		return errorToJSON(500, err)
+	}
+
+	if commandTag.RowsAffected() == 0 {
+		return newJSONerror(204, "this establishment is already not followed")
+	}
+
+	return nil
+}
+
+func (f *Follow) list(roles scope) ([]Follow, Jerror) {
+	sqlFollow := `select 
+	f.comment,
+	f.since,
+	et.siret,
+	et.siren,
+	en.raison_sociale, 
+	et.commune, 
+	d.libelle, 
+	d.code,
+	s.score,
+	s.diff,
+	di.chiffre_affaire,
+	di.arrete_bilan,
+	di.variation_ca,
+	di.resultat_expl,
+	ef.effectif,
+	n.libelle,
+	n1.libelle,
+	et.ape,
+	coalesce(ep.last_procol, 'in_bonis') as last_procol,
+	case when 'dgefp' = any($4) then coalesce(ap.ap, false) else null end as activite_partielle ,
+	case when 'urssaf' then 
+		case when u.dette[0] > u.dette[1] or u.dette[1] > u.dette[2] then true else false end 
+	else null end as hausseUrssaf,
+	s.alert,
+	r.roles && $1 as visible,
+	et.departement = any($2) as in_zone,
+	true as followed
+	from etablissement_follow f
+	inner join v_roles r on r.siren = f.siren
+	inner join etablissement0 et on et.siret = f.siret
+	inner join entreprise0 en on en.siren = f.siren
+	inner join departements d on d.code = et.departement
+	inner join naf n on n.code = et.ape
+	inner join naf n1 on n.id_n1 = n1.id
+	left join v_last_effectif ef on ef.siret = f.siret
+	left join v_hausse_urssaf u on u.siret = f.siret
+	left join v_apdemande ap on ap.siret = f.siret
+	left join v_last_procol ep on ep.siret = f.siret
+	left join v_diane_variation_ca di on di.siren = f.siren
+	left join scores s on s.siret = f.siret and s.libelle_liste = $3
+	where f.username = $4
+	`
+
+	rows, err := db.Query(context.Background(), sqlFollow, roles, f.Username)
+	if err != nil {
+		return nil, errorToJSON(500, err)
+	}
+
+	var follows []Follow
+	for rows.Next() {
+		var f Follow
+		var e Score
+		err := rows.Scan(
+			&f.Comment,
+			&f.Since,
+			&e.Siret,
+			&e.Siren,
+			&e.RaisonSociale,
+			&e.Commune,
+			&e.LibelleDepartement,
+			&e.Departement,
+			&e.Score,
+			&e.Diff,
+			&e.DernierCA,
+			&e.ArreteBilan,
+			&e.VariationCA,
+			&e.DernierREXP,
+			&e.DernierEffectif,
+			&e.LibelleActivite,
+			&e.LibelleActiviteN1,
+			&e.CodeActivite,
+			&e.EtatProcol,
+			&e.ActivitePartielle,
+			&e.HausseUrssaf,
+			&e.Alert,
+			&e.InZone,
+			&e.Followed,
+		)
+		if err != nil {
+			return nil, errorToJSON(500, err)
+		}
+		f.Etablissement = &e
+		f.Active = true
+		follows = append(follows, f)
+	}
+
+	return follows, nil
 }

--- a/migrations/200803_2_create_etablissement.sql
+++ b/migrations/200803_2_create_etablissement.sql
@@ -118,7 +118,7 @@ create table etablissement_follow (
   active   boolean,
   since    timestamp,
   until    timestamp,
-  comment  bytea  
+  comment  text  
 );
 
 create sequence etablissement_comment_id;


### PR DESCRIPTION
Quelques ajustements dans cette PR:
- la recherche renvoie les informations urssaf, dgefp et alert pour les entreprise suivies
- les listes contiennent désormais les entreprises suivies (la zone géographique reste respectée)

Par ailleurs, la liste des entreprises suivies est maintenant retournée avec les établissements au format score… Étant donné qu'on attend pas des listes très longues je n'ai pas mis en place de pagination, cela pourra être fait si le besoin se fait sentir.

Les scores fournis dans ces réponses proviennent de la dernière liste connue.

J'ai aussi corrigé une bétise de format dans la base de données, du coup cette version nécessite de casser/remonter le schéma.
