### PR TITLE
changement du format d'écriture dans excel

### DIFF
--- a/follow.go
+++ b/follow.go
@@ -257,7 +257,9 @@ func (follows Follows) toXLS() ([]byte, Jerror) {
 			row.AddCell().Value = ""
 		}
 		row.AddCell().Value = fmt.Sprintf("%s", *f.EtablissementSummary.CodeActivite)
-		row.AddCell().Value = fmt.Sprintf("%s", *f.EtablissementSummary.LibelleActivite)
+		if f.EtablissementSummary.LibelleActivite != nil {
+			row.AddCell().Value = fmt.Sprintf("%s", *f.EtablissementSummary.LibelleActivite)
+		}
 		row.AddCell().Value = fmt.Sprintf("%s", *coalescepString(f.EtablissementSummary.Alert, &EmptyString))
 		row.AddCell().Value = fmt.Sprintf("%s", *f.EtablissementSummary.Since)
 		row.AddCell().Value = fmt.Sprintf("%s", *f.EtablissementSummary.Category)

--- a/score.go
+++ b/score.go
@@ -274,7 +274,7 @@ func (liste *Liste) toXLS(params paramsListeScores) ([]byte, Jerror) {
 		row.AddCell().Value = fmt.Sprintf("%s", score.Siret)
 		row.AddCell().Value = fmt.Sprintf("%s", *score.CodeDepartement)
 		row.AddCell().Value = fmt.Sprintf("%s", *score.RaisonSociale)
-		row.AddCell().Value = fmt.Sprintf("%f", *score.Effectif)
+		row.AddCell().Value = fmt.Sprintf("%i", *score.Effectif)
 		row.AddCell().Value = fmt.Sprintf("%s", *score.CodeActivite)
 		row.AddCell().Value = fmt.Sprintf("%s", *score.LibelleActivite)
 		row.AddCell().Value = fmt.Sprintf("%s", *score.Alert)

--- a/score.go
+++ b/score.go
@@ -274,7 +274,7 @@ func (liste *Liste) toXLS(params paramsListeScores) ([]byte, Jerror) {
 		row.AddCell().Value = fmt.Sprintf("%s", score.Siret)
 		row.AddCell().Value = fmt.Sprintf("%s", *score.CodeDepartement)
 		row.AddCell().Value = fmt.Sprintf("%s", *score.RaisonSociale)
-		row.AddCell().Value = fmt.Sprintf("%i", *score.Effectif)
+		row.AddCell().Value = fmt.Sprintf("%d", int(*score.Effectif))
 		row.AddCell().Value = fmt.Sprintf("%s", *score.CodeActivite)
 		row.AddCell().Value = fmt.Sprintf("%s", *score.LibelleActivite)
 		row.AddCell().Value = fmt.Sprintf("%s", *score.Alert)

--- a/score.go
+++ b/score.go
@@ -276,7 +276,9 @@ func (liste *Liste) toXLS(params paramsListeScores) ([]byte, Jerror) {
 		row.AddCell().Value = fmt.Sprintf("%s", *score.RaisonSociale)
 		row.AddCell().Value = fmt.Sprintf("%d", int(*score.Effectif))
 		row.AddCell().Value = fmt.Sprintf("%s", *score.CodeActivite)
-		row.AddCell().Value = fmt.Sprintf("%s", *score.LibelleActivite)
+		if score.LibelleActivite != nil {
+			row.AddCell().Value = fmt.Sprintf("%s", *score.LibelleActivite)
+		}
 		row.AddCell().Value = fmt.Sprintf("%s", *score.Alert)
 	}
 


### PR DESCRIPTION
Une micro-PR d'1 caractère pour améliorer l'export excel en mettant un entier à la place d'un float interprété comme un champ texte par excel.

+ workaround d'un bug quand un établissement avec un code activité en dehors de nafRev2