### PR TITLE
fix: petites améliorations syntaxiques.

### DIFF
--- a/db.go
+++ b/db.go
@@ -47,7 +47,7 @@ func connectDB() *pgxpool.Pool {
 
 func listDatabaseMigrations(db *pgxpool.Pool) []migrationScript {
 	var exists bool
-	err := db.QueryRow(context.Background(),
+	db.QueryRow(context.Background(),
 		`select exists
 		(select 1
 		 from information_schema.tables 
@@ -202,76 +202,4 @@ func loadReferences(db *pgxpool.Pool) reference {
 	}
 
 	return result
-}
-
-func createIndexesBatch() pgx.Batch {
-	batch := pgx.Batch{}
-	batch.Queue("create index idx_etablissement_siret on etablissement (siret) where version = 0;")
-	batch.Queue("create index idx_etablissement_siren on etablissement (siren) where version = 0;")
-	batch.Queue("create index idx_etablissement_departement on etablissement (departement) where version = 0;")
-	batch.Queue("create index idx_etablissement_hash on etablissement (siret, hash) where version in (0, 1);")
-	batch.Queue("create index idx_etablissement_naf on etablissement (ape) where version = 0;")
-	batch.Queue("create index idx_entreprise_siren on entreprise (siren) where version = 0;")
-	batch.Queue("create index idx_entreprise_hash on entreprise (siren, hash) where version in (0, 1);")
-	batch.Queue("create index idx_etablissement_procol_siret on etablissement_procol (siret) where version = 0;")
-	batch.Queue("create index idx_etablissement_procol_hash on etablissement_procol (siret, hash) where version in (0, 1);")
-	batch.Queue("create index idx_etablissement_delai_siret on etablissement_delai (siret) where version = 0;")
-	batch.Queue("create index idx_etablissement_delai_hash on etablissement_delai (siret, hash) where version in (0, 1);")
-	batch.Queue("create index idx_etablissement_periode_urssaf_siret on etablissement_periode_urssaf (siret) where version = 0;")
-	batch.Queue("create index idx_etablissement_periode_urssaf_siren on etablissement_periode_urssaf (siren) where version = 0;")
-	batch.Queue("create index idx_etablissement_periode_urssaf_hash on etablissement_periode_urssaf (siret, hash) where version in (0, 1);")
-	batch.Queue("create index idx_etablissement_apconso_siret on etablissement_apconso (siret) where version = 0;")
-	batch.Queue("create index idx_etablissement_apconso_siren on etablissement_apconso (siren) where version = 0;")
-	batch.Queue("create index idx_etablissement_apconso_hash on etablissement_apconso (siret, hash) where version in (0, 1);")
-	batch.Queue("create index idx_etablissement_apdemande_siret on etablissement_apdemande (siret) where version = 0;")
-	batch.Queue("create index idx_etablissement_apdemande_siren on etablissement_apdemande (siren) where version = 0;")
-	batch.Queue("create index idx_etablissement_apdemande_hash on etablissement_apdemande (siret, hash) where version in (0, 1);")
-	batch.Queue("create index idx_score_siret on score (siret) where version = 0;")
-	batch.Queue("create index idx_score_siren on score (siren) where version = 0;")
-	batch.Queue("create index idx_score_alert on score (alert) where version = 0;")
-	batch.Queue("create index idx_score_liste on score (libelle_liste) where version = 0;")
-	batch.Queue("create index idx_score_score on score (score) where version = 0;")
-	batch.Queue("create index idx_score_hash on score (siret, hash) where version in (0, 1);")
-	batch.Queue("create index idx_liste_libelle on liste (libelle) where version = 0;")
-	batch.Queue("create index idx_naf_code_niveau on naf (code, niveau);")
-	batch.Queue("create index idx_etablissement_follow on etablissement_follow (siret, username, active);")
-	batch.Queue("create index idx_naf_code on naf  (code);")
-	batch.Queue("create index idx_naf_n1 on naf (id_n1);")
-	return batch
-}
-
-func dropIndexesBatch() pgx.Batch {
-	batch := pgx.Batch{}
-	batch.Queue("drop index idx_etablissement_siret;")
-	batch.Queue("drop index idx_etablissement_siren;")
-	batch.Queue("drop index idx_etablissement_departement;")
-	batch.Queue("drop index idx_etablissement_hash;")
-	batch.Queue("drop index idx_etablissement_naf;")
-	batch.Queue("drop index idx_entreprise_siren;")
-	batch.Queue("drop index idx_entreprise_hash;")
-	batch.Queue("drop index idx_etablissement_procol_siret;")
-	batch.Queue("drop index idx_etablissement_procol_hash;")
-	batch.Queue("drop index idx_etablissement_delai_siret;")
-	batch.Queue("drop index idx_etablissement_delai_hash;")
-	batch.Queue("drop index idx_etablissement_periode_urssaf_siret;")
-	batch.Queue("drop index idx_etablissement_periode_urssaf_siren;")
-	batch.Queue("drop index idx_etablissement_periode_urssaf_hash;")
-	batch.Queue("drop index idx_etablissement_apconso_siret;")
-	batch.Queue("drop index idx_etablissement_apconso_siren;")
-	batch.Queue("drop index idx_etablissement_apconso_hash;")
-	batch.Queue("drop index idx_etablissement_apdemande_siret;")
-	batch.Queue("drop index idx_etablissement_apdemande_siren;")
-	batch.Queue("drop index idx_etablissement_apdemande_hash;")
-	batch.Queue("drop index idx_score_siret;")
-	batch.Queue("drop index idx_score_siren;")
-	batch.Queue("drop index idx_score_alert;")
-	batch.Queue("drop index idx_score_liste;")
-	batch.Queue("drop index idx_score_score;")
-	batch.Queue("drop index idx_score_hash;")
-	batch.Queue("drop index idx_liste_libelle;")
-	batch.Queue("drop index idx_naf_code_niveau;")
-	batch.Queue("drop index idx_etablissement_follow;")
-	batch.Queue("drop index idx_naf_code;")
-	batch.Queue("drop index idx_naf_n1;")
-	return batch
 }

--- a/entreprise.go
+++ b/entreprise.go
@@ -60,11 +60,6 @@ type Paydex struct {
 	NBJours    []int       `json:"nb_jours"`
 }
 
-type findEtablissementsParams struct {
-	Sirets []string `json:"sirets"`
-	Sirens []string `json:"sirens"`
-}
-
 // Etablissements Collection d'établissements
 type Etablissements struct {
 	Query struct {

--- a/fce.go
+++ b/fce.go
@@ -1,38 +1,38 @@
 package main
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"encoding/json"
-	"github.com/spf13/viper"
-	"github.com/gin-gonic/gin"
+	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
-	"io"
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
-	"encoding/hex"
-	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spf13/viper"
 )
 
 // Fce type pour l'API Fiche Commune Entreprise
 type Fce struct {
-	Success		bool 	`json:"success"`
-	Credential 	string 	`json:"credential"`
+	Success    bool   `json:"success"`
+	Credential string `json:"credential"`
 }
 
 func askFceCredentials() ([]byte, error) {
 	apiFceURL := viper.GetString("apiFceURL")
-	req, err := http.NewRequest("GET", apiFceURL + "askCredential", nil)
+	req, err := http.NewRequest("GET", apiFceURL+"askCredential", nil)
 	if err != nil {
 		return nil, err
 	}
 	q := req.URL.Query()
-	now := time.Now() 
+	now := time.Now()
 	ts := strconv.FormatInt(now.Unix(), 10)
-    q.Add("ts", ts)
+	q.Add("ts", ts)
 	apiKey := viper.GetString("apiFceKey")
 	q.Add("api_key", apiKey)
 	req.URL.RawQuery = q.Encode()
@@ -91,25 +91,26 @@ func encrypt(stringToEncrypt string, key string) (string, error) {
 	return fmt.Sprintf("%x", encryptedBytes), nil
 }
 
-func decrypt(encryptedString string, key string) (string, error) {
-	encryptedBytes, _ := hex.DecodeString(encryptedString)
-	keyBytes := []byte(key)
-	cipherBlock, err := aes.NewCipher(keyBytes)
-	if err != nil {
-		return "", err
-	}
-	aesGCM, err := cipher.NewGCM(cipherBlock)
-	if err != nil {
-		return "", err
-	}
-	nonceSize := aesGCM.NonceSize()
-	nonce, data := encryptedBytes[:nonceSize], encryptedBytes[nonceSize:]
-	decryptedBytes, err := aesGCM.Open(nil, nonce, data, nil)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%s", decryptedBytes), nil
-}
+// TODO: unused function ? cleanup ?
+// func decrypt(encryptedString string, key string) (string, error) {
+// 	encryptedBytes, _ := hex.DecodeString(encryptedString)
+// 	keyBytes := []byte(key)
+// 	cipherBlock, err := aes.NewCipher(keyBytes)
+// 	if err != nil {
+// 		return "", err
+// 	}
+// 	aesGCM, err := cipher.NewGCM(cipherBlock)
+// 	if err != nil {
+// 		return "", err
+// 	}
+// 	nonceSize := aesGCM.NonceSize()
+// 	nonce, data := encryptedBytes[:nonceSize], encryptedBytes[nonceSize:]
+// 	decryptedBytes, err := aesGCM.Open(nil, nonce, data, nil)
+// 	if err != nil {
+// 		return "", err
+// 	}
+// 	return fmt.Sprintf("%s", decryptedBytes), nil
+// }
 
 func makeFceVisitURL(siret string, credential string, username string) (string, error) {
 	fceVisitURL := viper.GetString("fceVisitURL") + "establishment/" + siret
@@ -122,6 +123,6 @@ func makeFceVisitURL(siret string, credential string, username string) (string, 
 	if err != nil {
 		return "", err
 	}
-	fceVisitURL +=  "?" + params.Encode()
+	fceVisitURL += "?" + params.Encode()
 	return fceVisitURL, nil
 }

--- a/follow.go
+++ b/follow.go
@@ -247,23 +247,23 @@ func (follows Follows) toXLS() ([]byte, Jerror) {
 		if err != nil {
 			return nil, errorToJSON(500, err)
 		}
-		row.AddCell().Value = fmt.Sprintf("%s", f.EtablissementSummary.Siren)
-		row.AddCell().Value = fmt.Sprintf("%s", f.EtablissementSummary.Siret)
-		row.AddCell().Value = fmt.Sprintf("%s", *f.EtablissementSummary.CodeDepartement)
-		row.AddCell().Value = fmt.Sprintf("%s", *f.EtablissementSummary.RaisonSociale)
+		row.AddCell().Value = f.EtablissementSummary.Siren
+		row.AddCell().Value = f.EtablissementSummary.Siret
+		row.AddCell().Value = *f.EtablissementSummary.CodeDepartement
+		row.AddCell().Value = *f.EtablissementSummary.RaisonSociale
 		if f.EtablissementSummary.Effectif != nil {
 			row.AddCell().Value = fmt.Sprintf("%f", *f.EtablissementSummary.Effectif)
 		} else {
 			row.AddCell().Value = ""
 		}
-		row.AddCell().Value = fmt.Sprintf("%s", *f.EtablissementSummary.CodeActivite)
+		row.AddCell().Value = *f.EtablissementSummary.CodeActivite
 		if f.EtablissementSummary.LibelleActivite != nil {
-			row.AddCell().Value = fmt.Sprintf("%s", *f.EtablissementSummary.LibelleActivite)
+			row.AddCell().Value = *f.EtablissementSummary.LibelleActivite
 		}
-		row.AddCell().Value = fmt.Sprintf("%s", *coalescepString(f.EtablissementSummary.Alert, &EmptyString))
-		row.AddCell().Value = fmt.Sprintf("%s", *f.EtablissementSummary.Since)
-		row.AddCell().Value = fmt.Sprintf("%s", *f.EtablissementSummary.Category)
-		row.AddCell().Value = fmt.Sprintf("%s", *f.EtablissementSummary.Comment)
+		row.AddCell().Value = *coalescepString(f.EtablissementSummary.Alert, &EmptyString)
+		row.AddCell().Value = f.EtablissementSummary.Since.String()
+		row.AddCell().Value = *f.EtablissementSummary.Category
+		row.AddCell().Value = *f.EtablissementSummary.Comment
 	}
 
 	data := bytes.NewBuffer(nil)

--- a/htree.go
+++ b/htree.go
@@ -1,20 +1,11 @@
 package main
 
 import (
-	"bytes"
-
 	"modernc.org/b"
 )
 
 type htree struct {
 	tree *b.Tree
-}
-
-func (t *htree) insert(hash []byte, id int) {
-	if t.tree == nil {
-		t.tree = b.TreeNew(hashCmp)
-	}
-	t.tree.Set(hash, id)
 }
 
 func (t *htree) contains(hash []byte) (int, bool) {
@@ -26,8 +17,4 @@ func (t *htree) contains(hash []byte) (int, bool) {
 		return 0, ok
 	}
 	return id.(int), ok
-}
-
-func hashCmp(a, b interface{}) int {
-	return bytes.Compare((a.([]byte)), (b.([]byte)))
 }

--- a/import.go
+++ b/import.go
@@ -108,12 +108,6 @@ type entreprise struct {
 	} `bson:"value"`
 }
 
-// Effectif detail
-type effectif struct {
-	Periode  time.Time `json:"periode"`
-	Effectif int       `json:"effectif"`
-}
-
 // Debit detail
 type debit struct {
 	PartOuvriere       float64   `json:"part_ouvriere"`
@@ -791,18 +785,6 @@ func scoreToListe() pgx.Batch {
 	return batch
 }
 
-type importObject struct {
-	ID    string      `json:"_id"`
-	Value importValue `json:"value"`
-}
-
-type importValue struct {
-	Sirets   *[]string      `json:"sirets"`
-	Bdf      *[]interface{} `json:"bdf"`
-	Diane    *[]diane       `json:"diane"`
-	SireneUL *sireneUL      `json:"sirene_ul"`
-}
-
 func importHandler(c *gin.Context) {
 	tx, err := db.Begin(context.Background())
 	if err != nil {
@@ -855,6 +837,9 @@ func processEntreprise(fileName string, htrees map[string]*htree, tx *pgx.Tx) er
 	defer file.Close()
 	batches, wg := newBatchRunner(tx)
 	unzip, err := gzip.NewReader(file)
+	if err != nil {
+		return err
+	}
 	decoder := json.NewDecoder(unzip)
 	i := 0
 	var batch pgx.Batch
@@ -912,6 +897,9 @@ func processEtablissement(fileName string, htrees map[string]*htree, tx *pgx.Tx)
 	}
 	batches, wg := newBatchRunner(tx)
 	unzip, err := gzip.NewReader(file)
+	if err != nil {
+		return err
+	}
 	decoder := json.NewDecoder(unzip)
 
 	i := 0

--- a/keycloak.go
+++ b/keycloak.go
@@ -23,32 +23,32 @@ type keycloakUser struct {
 	roles     scope
 }
 
-func (sc scope) containsRole(role string) bool {
-	for _, s := range sc {
-		if role == s {
-			return true
-		}
-	}
-	return false
-}
+// func (sc scope) containsRole(role string) bool {
+// 	for _, s := range sc {
+// 		if role == s {
+// 			return true
+// 		}
+// 	}
+// 	return false
+// }
 
-func (sc scope) containsScope(roles scope) bool {
-	for _, r := range roles {
-		if !sc.containsRole(r) {
-			return false
-		}
-	}
-	return true
-}
+// func (sc scope) containsScope(roles scope) bool {
+// 	for _, r := range roles {
+// 		if !sc.containsRole(r) {
+// 			return false
+// 		}
+// 	}
+// 	return true
+// }
 
-func (sc scope) overlapsScope(roles scope) bool {
-	for _, r := range roles {
-		if sc.containsRole(r) {
-			return true
-		}
-	}
-	return false
-}
+// func (sc scope) overlapsScope(roles scope) bool {
+// 	for _, r := range roles {
+// 		if sc.containsRole(r) {
+// 			return true
+// 		}
+// 	}
+// 	return false
+// }
 
 func connectKC() gocloak.GoCloak {
 	keycloak := gocloak.NewClient(viper.GetString("keycloakHostname"))
@@ -161,7 +161,7 @@ func scopeFromContext(c *gin.Context) scope {
 func (sc scope) zoneGeo() []string {
 	var zone []string
 	for _, role := range sc {
-		departements, _ := ref.zones[role]
+		departements := ref.zones[role]
 		zone = append(zone, departements...)
 	}
 	for _, s := range sc {
@@ -261,6 +261,10 @@ func fetchUsersAndRoles() (map[string]keycloakUser, map[string]*string, Jerror) 
 		jwt.AccessToken,
 		realm,
 		*clients[0].ID)
+
+	if err != nil {
+		return nil, nil, errorToJSON(500, err)
+	}
 
 	roleMap := make(map[string]*string)
 	for _, r := range roles {

--- a/score.go
+++ b/score.go
@@ -269,52 +269,52 @@ func (liste *Liste) toXLS(params paramsListeScores) ([]byte, Jerror) {
 		if err != nil {
 			return nil, errorToJSON(500, err)
 		}
-		row.AddCell().Value = fmt.Sprintf("%s", liste.ID)
-		row.AddCell().Value = fmt.Sprintf("%s", score.Siren)
-		row.AddCell().Value = fmt.Sprintf("%s", score.Siret)
-		row.AddCell().Value = fmt.Sprintf("%s", *score.CodeDepartement)
-		row.AddCell().Value = fmt.Sprintf("%s", *score.RaisonSociale)
+		row.AddCell().Value = liste.ID
+		row.AddCell().Value = score.Siren
+		row.AddCell().Value = score.Siret
+		row.AddCell().Value = *score.CodeDepartement
+		row.AddCell().Value = *score.RaisonSociale
 		row.AddCell().Value = fmt.Sprintf("%d", int(*score.Effectif))
-		row.AddCell().Value = fmt.Sprintf("%s", *score.CodeActivite)
+		row.AddCell().Value = *score.CodeActivite
 		if score.LibelleActivite != nil {
-			row.AddCell().Value = fmt.Sprintf("%s", *score.LibelleActivite)
+			row.AddCell().Value = *score.LibelleActivite
 		}
-		row.AddCell().Value = fmt.Sprintf("%s", *score.Alert)
+		row.AddCell().Value = *score.Alert
 	}
 
-	sheetParams, err := xlFile.AddSheet("parameters")
+	sheetParams, _ := xlFile.AddSheet("parameters")
 	row = sheetParams.AddRow()
-	s, err := json.Marshal(params.Activites)
+	s, _ := json.Marshal(params.Activites)
 	row.AddCell().Value = "activites"
 	row.AddCell().Value = string(s)
 
 	row = sheetParams.AddRow()
-	s, err = json.Marshal(params.Departements)
+	s, _ = json.Marshal(params.Departements)
 	row.AddCell().Value = "departements"
 	row.AddCell().Value = string(s)
 
 	row = sheetParams.AddRow()
-	s, err = json.Marshal(params.EffectifMin)
+	s, _ = json.Marshal(params.EffectifMin)
 	row.AddCell().Value = "effectifMin"
 	row.AddCell().Value = string(s)
 
 	row = sheetParams.AddRow()
-	s, err = json.Marshal(params.EffectifMax)
+	s, _ = json.Marshal(params.EffectifMax)
 	row.AddCell().Value = "effectifMax"
 	row.AddCell().Value = string(s)
 
 	row = sheetParams.AddRow()
-	s, err = json.Marshal(params.EtatsProcol)
+	s, _ = json.Marshal(params.EtatsProcol)
 	row.AddCell().Value = "etatsProcol"
 	row.AddCell().Value = string(s)
 
 	row = sheetParams.AddRow()
-	s, err = json.Marshal(params.Filter)
+	s, _ = json.Marshal(params.Filter)
 	row.AddCell().Value = "filter"
 	row.AddCell().Value = string(s)
 
 	row = sheetParams.AddRow()
-	s, err = json.Marshal(params.IgnoreZone)
+	s, _ = json.Marshal(params.IgnoreZone)
 	row.AddCell().Value = "ignorezone"
 	row.AddCell().Value = string(s)
 

--- a/summary.go
+++ b/summary.go
@@ -52,8 +52,8 @@ type Summary struct {
 }
 
 type summaries struct {
-	summaryParams summaryParams
-	global        struct {
+	//summaryParams summaryParams
+	global struct {
 		count    *int
 		countF1  *int
 		countF2  *int

--- a/wekanExport.go
+++ b/wekanExport.go
@@ -35,6 +35,7 @@ type abstractProcol struct {
 	Action    string    `json:"action"`
 	Stade     string    `json:"stade"`
 }
+
 type dbFollowExport struct {
 	codeDepartement                   string
 	libelleDepartement                string


### PR DESCRIPTION
Une petite PR pour fixer quelques problèmes qui polluent la console avec go staticcheck qui vérifie des petites choses comme l'utilisation optimale de certaines fonctions très communes, ou l'utilisation de certaines variables qui ne provoquent pas de problème de compilation…

J'ai changé quelques petites choses dans wekan.go en pensant que c'était probablement mieux, mais peut être que ce n'est pas souhaitable ? De façon générale les erreurs d'Unmarshall n'étaient pas toute utilisées, j'ai ajouté une gestion d'erreur qui interrompt la transaction et renvoie l'erreur … Ce n'est pas forcément optimal et peut être que parfois c'est même génant ?

Il reste quelques avertissements que je n'ai pas traité car ils devraient disparaître dans la branche d'export wekan.