### PR TITLE
Import des bilans INPI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/signaux-faibles/goSirene v0.2.4
+	github.com/signaux-faibles/libinpirncs v0.0.0-20211105210201-f15bdec3899c
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/viper v1.8.1
 	github.com/tealeg/xlsx v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -447,6 +447,8 @@ github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXY
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/signaux-faibles/goSirene v0.2.4 h1:m74h4GNNTI2aQryakGj2vJIWl6/JUSLSdxetHOQxYQg=
 github.com/signaux-faibles/goSirene v0.2.4/go.mod h1:YdHQWRCIiyAmPievzBtFwsvA61MXrPkuPkJuGUu9kmU=
+github.com/signaux-faibles/libinpirncs v0.0.0-20211105210201-f15bdec3899c h1:nIAE2qg0RlOSEdiWToIX/vKpoRwBqlyyrBUJEvJm3Fc=
+github.com/signaux-faibles/libinpirncs v0.0.0-20211105210201-f15bdec3899c/go.mod h1:xUv80N8I0XDZI738/lAsqyPqzQHDKm0jdQebVwI2K4g=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=

--- a/main.go
+++ b/main.go
@@ -110,14 +110,13 @@ func runAPI() {
 	// utils.GET("/wekanListCards", wekanGetListCardsHandler)
 	utils.GET("/sireneImport", sireneImportHandler)
 	utils.GET("/listImport/:algo", listImportHandler)
-
+	utils.GET("/rncsImport/:date", rncsImport)
 	wekan := router.Group("/wekan", getKeycloakMiddleware(), logMiddleware)
 	wekan.GET("/cards/:siret", wekanGetCardHandler)
 	wekan.POST("/cards/:siret", wekanNewCardHandler)
 	wekan.GET("/join/:cardId", wekanJoinCardHandler)
 	wekan.GET("/config", wekanConfigHandler)
 	wekan.GET("/reloadConfig", wekanReloadConfigHandler)
-
 	log.Print("Running API on " + viper.GetString("bind"))
 	err := router.Run(viper.GetString("bind"))
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -110,7 +110,9 @@ func runAPI() {
 	// utils.GET("/wekanListCards", wekanGetListCardsHandler)
 	utils.GET("/sireneImport", sireneImportHandler)
 	utils.GET("/listImport/:algo", listImportHandler)
-	utils.GET("/rncsImport/:date", rncsImport)
+	utils.POST("/rncsImport", rncsImportHandler)
+	utils.GET("/rncsImport", rncsImportFilesHandler)
+
 	wekan := router.Group("/wekan", getKeycloakMiddleware(), logMiddleware)
 	wekan.GET("/cards/:siret", wekanGetCardHandler)
 	wekan.POST("/cards/:siret", wekanNewCardHandler)

--- a/rncs.go
+++ b/rncs.go
@@ -1,7 +1,81 @@
 package main
 
-import "github.com/gin-gonic/gin"
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 
-func rncsImport(c *gin.Context) {
+	"github.com/gin-gonic/gin"
+	rncs "github.com/signaux-faibles/libinpirncs"
+	"github.com/spf13/viper"
+)
+
+func rncsImportHandler(c *gin.Context) {
+	input, err := ioutil.ReadAll(c.Request.Body)
+	if err != nil {
+		c.JSON(500, "rncsImportHandler: "+err.Error())
+	}
+	bilan, err := rncs.ParseBilan(input, "")
+	if err != nil {
+		c.JSON(400, "ParseBilan: "+err.Error())
+	}
+	err = updateDianeFromRncs([]rncs.Bilan{bilan})
+	if err != nil {
+		c.JSON(500, "updateDianeFromRncs: "+err.Error())
+	}
 	c.JSON(501, "not implemented")
+}
+
+func rncsImportFilesHandler(c *gin.Context) {
+	path := viper.GetString("rncsPath")
+	var bilanFiles []string
+	err := filepath.Walk(path, rncsImportFile(&bilanFiles))
+	if err != nil {
+		c.JSON(500, "rncsImportFolderHandler: "+err.Error())
+	}
+	bilans, err := getBilansFromFiles(bilanFiles)
+	if err != nil {
+		c.JSON(500, "getBilanFromFiles: "+err.Error())
+	}
+	fmt.Println(bilans)
+}
+
+func rncsImportFile(bilansFiles *[]string) func(string, os.FileInfo, error) error {
+	return func(path string, file os.FileInfo, err error) error {
+		l := len(file.Name())
+		if len(file.Name()) > 3 && strings.ToLower(file.Name()[l-3:l]) == "xml" {
+			*bilansFiles = append(*bilansFiles, path)
+		}
+		return nil
+	}
+}
+
+func getBilansFromFiles(bilanFiles []string) ([]rncs.Bilan, error) {
+	var bilans []rncs.Bilan
+	for _, file := range bilanFiles {
+		if bilanData, err := ioutil.ReadFile(file); err == nil {
+			if bilan, err := rncs.ParseBilan(bilanData, file); err == nil {
+				bilans = append(bilans, bilan)
+			} else {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
+	}
+	return bilans, nil
+}
+
+func updateDianeFromRncs(bilans []rncs.Bilan) error {
+	for _, b := range bilans {
+		d, err := rncsToDiane(b)
+	}
+	return nil
+}
+
+func rncsToDiane(rncs.Bilan) (diane, error) {
+
+	return diane{}, nil
 }

--- a/rncs.go
+++ b/rncs.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/gin-gonic/gin"
+
+func rncsImport(c *gin.Context) {
+	c.JSON(501, "not implemented")
+}


### PR DESCRIPTION
Cette fonctionnalité permet d'importer jour après jour les bilans et comptes de résultats déposés à l'INPI.
Comme la récupération des données est complexe à partir du ftp de l'INPI, la source est un mirroir repackagé par Christian Quest proposant les mêmes fichiers dans un format bien plus facile à récupérer et exploiter.
