### PR TITLE
Gestion des cartes multiples pour un SIRET

### DIFF
--- a/export.go
+++ b/export.go
@@ -55,9 +55,7 @@ type WekanExport struct {
 	DateFinSuivi               string   `json:"date_fin_suivi"`
 	DescriptionWekan           string   `json:"description_wekan"`
 	Labels                     []string `json:"labels"`
-	Board                      string   `json:"board"`
-	Swimlane                   string   `json:"swimlane"`
-	Column                     string   `json:"column"`
+	Board                      string   `json:"-"`
 }
 
 type dbExport struct {
@@ -433,6 +431,9 @@ func (c Card) join() []WekanExport {
 	}
 
 	output := []WekanExport{}
+	if len(c.WekanCards) == 0 {
+		c.WekanCards = append(c.WekanCards, nil)
+	}
 	for _, card := range c.WekanCards {
 		we := WekanExport{
 			RaisonSociale:              c.dbExport.RaisonSociale,
@@ -458,20 +459,20 @@ func (c Card) join() []WekanExport {
 			ResultatExploitation:       libelleFin(c.dbExport.ResultatExploitation),
 			ProcedureCollective:        procolSwitch[c.dbExport.ProcedureCollective],
 			DetectionSF:                libelleAlerte(c.dbExport.DerniereListe, c.dbExport.DerniereAlerte),
-			Board:                      card.Board(),
 		}
 
-		if c.WekanCards != nil {
+		if card != nil {
 			we.DateDebutSuivi = dateUrssaf(card.StartAt)
 			we.DescriptionWekan = card.Description + "\n\n" + strings.ReplaceAll(strings.Join(card.Comments, "\n\n"), "#export", "")
 			we.Labels = wc.labelForLabelsIDs(card.LabelIds, card.BoardId)
 			if card.EndAt != nil {
 				we.DateFinSuivi = dateUrssaf(*card.EndAt)
 			}
+			we.Board = card.Board()
 		} else {
 			we.DateDebutSuivi = dateUrssaf(c.dbExport.DateDebutSuivi)
 		}
-
+		output = append(output, we)
 	}
 	return output
 }

--- a/export.go
+++ b/export.go
@@ -321,6 +321,7 @@ func (cards Cards) xlsx(wekan bool) ([]byte, error) {
 		row.AddCell().Value = "Étiquettes"
 		row.AddCell().Value = "Présentation de l'enteprise, difficultés et actions"
 		row.AddCell().Value = "Fin du suivi Wekan"
+		row.AddCell().Value = "Tableau"
 	}
 
 	for _, c := range cards {
@@ -356,6 +357,7 @@ func (cards Cards) xlsx(wekan bool) ([]byte, error) {
 					row.AddCell().Value = strings.Join(e.Labels, ", ")
 					row.AddCell().Value = e.DescriptionWekan
 					row.AddCell().Value = e.DateFinSuivi
+					row.AddCell().Value = e.Board
 				}
 			}
 		}
@@ -456,6 +458,7 @@ func (c Card) join() []WekanExport {
 			ResultatExploitation:       libelleFin(c.dbExport.ResultatExploitation),
 			ProcedureCollective:        procolSwitch[c.dbExport.ProcedureCollective],
 			DetectionSF:                libelleAlerte(c.dbExport.DerniereListe, c.dbExport.DerniereAlerte),
+			Board:                      card.Board(),
 		}
 
 		if c.WekanCards != nil {

--- a/follow.go
+++ b/follow.go
@@ -285,7 +285,7 @@ func getCards(s session, params paramsGetCards) ([]*Card, error) {
 			cards = append(cards, &card)
 			cardsMap[siret] = &card
 			sirets = append(sirets, siret)
-			if contains(w.Members, userID) {
+			if contains(append(w.Members, w.Assignees...), userID) {
 				followedSirets = append(followedSirets, siret)
 			}
 		}
@@ -339,6 +339,7 @@ func getCards(s session, params paramsGetCards) ([]*Card, error) {
 }
 
 func followSiretsFromWekan(username string, sirets []string) error {
+	fmt.Println(sirets)
 	tx, err := db.Begin(context.Background())
 	if err != nil {
 		return err

--- a/follow.go
+++ b/follow.go
@@ -239,9 +239,9 @@ type paramsGetCards struct {
 }
 
 type Card struct {
-	Summary   *Summary   `json:"summary"`
-	WekanCard *WekanCard `json:"wekanCard"`
-	dbExport  *dbExport
+	Summary    *Summary     `json:"summary"`
+	WekanCards []*WekanCard `json:"wekanCard"`
+	dbExport   *dbExport
 }
 
 type Cards []*Card
@@ -281,7 +281,7 @@ func getCards(s session, params paramsGetCards) ([]*Card, error) {
 			if err != nil {
 				continue
 			}
-			card := Card{nil, w, nil}
+			card := Card{nil, []*WekanCard{w}, nil}
 			cards = append(cards, &card)
 			cardsMap[siret] = &card
 			sirets = append(sirets, siret)

--- a/wekan.go
+++ b/wekan.go
@@ -623,6 +623,7 @@ type WekanCard struct {
 	BoardId      string     `bson:"boardId"`
 	SwimlaneID   string     `bson:"swimlaneId"`
 	Members      []string   `bson:"members"`
+	Assignees    []string   `bson:"assignees"`
 	Rank         float64    `bson:"sort"`
 	Description  string     `bson:"description"`
 	StartAt      time.Time  `bson:"startAt"`
@@ -936,6 +937,7 @@ func cardsPipeline(username *string, boardIds []string, swimlaneIds []string, li
 				"startAt":      1,
 				"endAt":        1,
 				"description":  1,
+				"assignees":    1,
 				"comments":     "$comments.text",
 			},
 		},

--- a/wekan.go
+++ b/wekan.go
@@ -637,6 +637,9 @@ type WekanCard struct {
 	}
 }
 
+func (c WekanCard) Board() string {
+	return wekanConfig.BoardForId(c.BoardId)
+}
 func (cs WekanCards) Sirets() []string {
 	var sirets []string
 	for _, c := range cs {

--- a/wekan.go
+++ b/wekan.go
@@ -638,9 +638,11 @@ type WekanCard struct {
 	}
 }
 
+// Board retourne le nom de la board où est la carte
 func (c WekanCard) Board() string {
-	return wekanConfig.BoardForId(c.BoardId)
+	return wekanConfig.BoardForID(c.BoardId)
 }
+
 func (cs WekanCards) Sirets() []string {
 	var sirets []string
 	for _, c := range cs {

--- a/wekan_config.go
+++ b/wekan_config.go
@@ -317,6 +317,12 @@ type WekanConfig struct {
 	mu       *sync.Mutex                  `json:"-"`
 }
 
+func (wc WekanConfig) BoardForId(boardId string) string {
+	wc.mu.Lock()
+	defer wc.mu.Unlock()
+	return wc.BoardIds[boardId].Title
+}
+
 func (wc WekanConfig) copy() WekanConfig {
 	var newc WekanConfig
 	newc.BoardIds = make(map[string]*WekanConfigBoard)

--- a/wekan_config.go
+++ b/wekan_config.go
@@ -318,10 +318,10 @@ type WekanConfig struct {
 }
 
 // BoardForID retourne le nom d'une board en échange de son id
-func (wc WekanConfig) BoardForID(boardId string) string {
+func (wc WekanConfig) BoardForID(boardID string) string {
 	wc.mu.Lock()
 	defer wc.mu.Unlock()
-	if board, ok := wc.BoardIds[boardId]; ok {
+	if board, ok := wc.BoardIds[boardID]; ok {
 		return board.Title
 	}
 	return ""

--- a/wekan_config.go
+++ b/wekan_config.go
@@ -320,7 +320,10 @@ type WekanConfig struct {
 func (wc WekanConfig) BoardForId(boardId string) string {
 	wc.mu.Lock()
 	defer wc.mu.Unlock()
-	return wc.BoardIds[boardId].Title
+	if board, ok := wc.BoardIds[boardId]; ok {
+		return board.Title
+	}
+	return ""
 }
 
 func (wc WekanConfig) copy() WekanConfig {

--- a/wekan_config.go
+++ b/wekan_config.go
@@ -317,7 +317,8 @@ type WekanConfig struct {
 	mu       *sync.Mutex                  `json:"-"`
 }
 
-func (wc WekanConfig) BoardForId(boardId string) string {
+// BoardForID retourne le nom d'une board en échange de son id
+func (wc WekanConfig) BoardForID(boardId string) string {
 	wc.mu.Lock()
 	defer wc.mu.Unlock()
 	if board, ok := wc.BoardIds[boardId]; ok {

--- a/wekan_test.go
+++ b/wekan_test.go
@@ -60,7 +60,7 @@ func readTestData() (Cards, error) {
 	for _, we := range wekanCards {
 		siret, _ := we.Siret()
 		if card, ok := cardIndex[siret]; ok {
-			card.WekanCard = &we
+			card.WekanCards = []*WekanCard{&we}
 		}
 	}
 

--- a/wekan_test.go
+++ b/wekan_test.go
@@ -70,6 +70,7 @@ func readTestData() (Cards, error) {
 func Test_WekanExportsDOCX(t *testing.T) {
 	t.Log("WekanExports can generate a non-zero length docx file")
 	cards, err := readTestData()
+
 	if err != nil {
 		t.Error(err.Error())
 		return
@@ -135,7 +136,7 @@ func Test_WekanExports(t *testing.T) {
 	if err != nil {
 		t.Errorf("could not hash WekanExport: %s", err.Error())
 	}
-	expected := "76305f6361636366363232633966643639303336653631343831303233366430643535"
+	expected := "76305f3266663335653439626432636163386564343133323462646339373731346330"
 	if fmt.Sprintf("%x", hash) != expected {
 		t.Errorf("unexpected results from joinExports(): \nstructhash should be: %s\nbut structHash is: %x", expected, hash)
 	}


### PR DESCRIPTION
# Objectif
Les utilisateurs peuvent être amenés à gérer plusieurs cartes pour le même établissement, soit dans des tableaux différents, soit dans le même tableau.

Cette PR règle les questions d'export en proposant de réunir les cartes d'un établissement dans le même DOCX ou en dupliquant autant qu'il se doit les lignes dans l'export excel.

Par ailleurs, cette PR ajoute dans le fichier excel une colonne avec la board d'origine pour permettre de dissocier l'origine des cartes plus facilement.