### PR TITLE
fix alertPreRedressement

### DIFF
--- a/import.go
+++ b/import.go
@@ -759,7 +759,7 @@ type scoreFile struct {
 	} `json:"explSelection"`
 	MacroRadar            map[string]float64 `json:"macroRadar"`
 	Redressements         []string           `json:"redressements"`
-	AlertPreRedressements string             `json:"alert_pre_redressements"`
+	AlertPreRedressements string             `json:"alertPreRedressements"`
 }
 
 func listImportHandler(c *gin.Context) {
@@ -859,9 +859,6 @@ func queueScoreToBatch(s scoreFile, batch *pgx.Batch) {
 	}
 	if s.Redressements == nil {
 		s.Redressements = make([]string, 0)
-	}
-	if s.AlertPreRedressements == "" {
-		s.AlertPreRedressements = s.Alert
 	}
 
 	batch.Queue(sqlScore,


### PR DESCRIPTION
Correction de l'import du champ alertPreRedressement
- passage d'`alert_pre_redressement` à a`lertPreRedressements` dans le namespace du fichier pivot
- suppression d'un hack qui forçait la valeur d'`alert` lors qu'`alertPreRedressement` est absent