### PR TITLE
fix currentlist on excel export

### DIFF
--- a/score.go
+++ b/score.go
@@ -104,9 +104,16 @@ func getXLSListeScores(c *gin.Context) {
 	var params paramsListeScores
 	err := c.Bind(&params)
 
+	listes, err := findAllListes()
+	if err != nil || len(listes) == 0 {
+		c.AbortWithStatus(204)
+		return
+	}
+
 	liste := Liste{
-		ID:    c.Param("id"),
-		Query: params,
+		ID:          c.Param("id"),
+		Query:       params,
+		CurrentList: listes[0].ID == c.Param("id"),
 	}
 
 	if err != nil || liste.ID == "" {


### PR DESCRIPTION
L'export excel des listes de détection a quelques lignes en moins par rapport à la visualisation dans l'application.
Cela est lié à l'absence du paramètre currentList dans la méthode d'export (qui conditionne le choix de la requête à exécuter).

Cette PR uniformise l'usage de ce paramètre pour avoir le même comportement que la visualisation directe.