### PR TITLE
fix: fermer les curseurs systématiquement après les avoir consommés

### DIFF
--- a/main_integration_test.go
+++ b/main_integration_test.go
@@ -139,10 +139,10 @@ func TestSearch(t *testing.T) {
 	order by substring(e.siret from 1 for 3)
 	limit 10
 	`)
+	defer rows.Close()
 	if err != nil {
 		t.Errorf("impossible de se connecter à la base: %s", err.Error())
 	}
-	defer rows.Close()
 
 	i := 0
 	for rows.Next() {

--- a/main_integration_test.go
+++ b/main_integration_test.go
@@ -142,6 +142,7 @@ func TestSearch(t *testing.T) {
 	if err != nil {
 		t.Errorf("impossible de se connecter à la base: %s", err.Error())
 	}
+	defer rows.Close()
 
 	i := 0
 	for rows.Next() {

--- a/pkg/core/comment.go
+++ b/pkg/core/comment.go
@@ -131,6 +131,7 @@ func (c *Comment) load() utils.Jerror {
 		return utils.ErrorToJSON(http.StatusInternalServerError, err)
 	}
 
+	defer rows.Close()
 	comments := make(map[int]*Comment)
 	var order []int
 

--- a/pkg/core/comment.go
+++ b/pkg/core/comment.go
@@ -127,11 +127,11 @@ func (c *Comment) load() utils.Jerror {
 	where e.siret = $1 order by e.id`
 
 	rows, err := db.Get().Query(context.Background(), sqlListComment, c.Siret)
+	defer rows.Close()
 	if err != nil {
 		return utils.ErrorToJSON(http.StatusInternalServerError, err)
 	}
 
-	defer rows.Close()
 	comments := make(map[int]*Comment)
 	var order []int
 

--- a/pkg/core/db.go
+++ b/pkg/core/db.go
@@ -10,6 +10,7 @@ func loadDepartementReferentiel() (map[CodeDepartement]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	r := make(map[CodeDepartement]string)
 	for rows.Next() {
 		var code CodeDepartement
@@ -34,6 +35,7 @@ func loadRegionsReferentiel() (map[Region][]CodeDepartement, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	r := make(map[Region][]CodeDepartement)
 	for rows.Next() {

--- a/pkg/core/db.go
+++ b/pkg/core/db.go
@@ -7,10 +7,10 @@ import (
 
 func loadDepartementReferentiel() (map[CodeDepartement]string, error) {
 	rows, err := db.Get().Query(context.Background(), "select code, libelle from departements")
+	defer rows.Close()
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 	r := make(map[CodeDepartement]string)
 	for rows.Next() {
 		var code CodeDepartement
@@ -31,11 +31,11 @@ func loadRegionsReferentiel() (map[Region][]CodeDepartement, error) {
     	union select 'France entière' as libelle, code from departements
 		order by libelle, code
 	`)
+	defer rows.Close()
 
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
 	r := make(map[Region][]CodeDepartement)
 	for rows.Next() {

--- a/pkg/core/entreprise.go
+++ b/pkg/core/entreprise.go
@@ -1032,11 +1032,11 @@ func getEntrepriseViewers(c *gin.Context) {
 
 	siren := c.Param("siren")
 	rows, err := db.Get().Query(context.Background(), sqlViewers, siren)
+	defer rows.Close()
 	if err != nil {
 		c.JSON(500, err.Error())
 		return
 	}
-	defer rows.Close()
 	var users []keycloakUser
 	for rows.Next() {
 		var u keycloakUser
@@ -1061,11 +1061,11 @@ func getEtablissementViewers(c *gin.Context) {
 
 	siren := c.Param("siret")[0:9]
 	rows, err := db.Get().Query(context.Background(), sqlViewers, siren)
+	defer rows.Close()
 	if err != nil {
 		c.JSON(500, err.Error())
 		return
 	}
-	defer rows.Close()
 	var users []keycloakUser
 	for rows.Next() {
 		var u keycloakUser

--- a/pkg/core/entreprise.go
+++ b/pkg/core/entreprise.go
@@ -1036,6 +1036,7 @@ func getEntrepriseViewers(c *gin.Context) {
 		c.JSON(500, err.Error())
 		return
 	}
+	defer rows.Close()
 	var users []keycloakUser
 	for rows.Next() {
 		var u keycloakUser
@@ -1064,6 +1065,7 @@ func getEtablissementViewers(c *gin.Context) {
 		c.JSON(500, err.Error())
 		return
 	}
+	defer rows.Close()
 	var users []keycloakUser
 	for rows.Next() {
 		var u keycloakUser

--- a/pkg/core/miscHandlers.go
+++ b/pkg/core/miscHandlers.go
@@ -11,11 +11,11 @@ import (
 
 func getCodesNaf(c *gin.Context) {
 	rows, err := db.Get().Query(context.Background(), "select code, libelle from naf where niveau=1")
+	defer rows.Close()
 	if err != nil {
 		utils.AbortWithError(c, err)
 		return
 	}
-	defer rows.Close()
 	var naf = make(map[string]string)
 	for rows.Next() {
 		var code string

--- a/pkg/core/miscHandlers.go
+++ b/pkg/core/miscHandlers.go
@@ -15,6 +15,7 @@ func getCodesNaf(c *gin.Context) {
 		utils.AbortWithError(c, err)
 		return
 	}
+	defer rows.Close()
 	var naf = make(map[string]string)
 	for rows.Next() {
 		var code string

--- a/pkg/core/score.go
+++ b/pkg/core/score.go
@@ -253,10 +253,10 @@ func findAllListes() ([]Liste, error) {
 		left join liste_description d on d.libelle_liste = l.libelle
 		where version=0 order by batch desc, algo
 	`)
+	defer rows.Close()
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
 	for rows.Next() {
 		var l Liste

--- a/pkg/core/summary.go
+++ b/pkg/core/summary.go
@@ -222,12 +222,12 @@ func getSummaries(params summaryParams) (Summaries, error) {
 	}
 
 	rows, err := db.Get().Query(context.Background(), sql, sqlParams...)
+	defer rows.Close()
 	if err != nil {
 		fmt.Println(err)
 		return Summaries{}, err
 	}
 
-	defer rows.Close()
 	sms := Summaries{}
 	for rows.Next() {
 		s := sms.NewSummary()

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -73,6 +73,8 @@ func listDatabaseMigrations(db *pgxpool.Pool) []migrationScript {
 		panic("can't get migrations from database: " + err.Error())
 	}
 	var dbMigrations []migrationScript
+	defer dbMigrationsCursor.Close()
+
 	for dbMigrationsCursor.Next() {
 		var m migrationScript
 		dbMigrationsCursor.Scan(&m.fileName, &m.hash)

--- a/pkg/test/testLibrary.go
+++ b/pkg/test/testLibrary.go
@@ -247,11 +247,11 @@ func GetSiret(t *testing.T, v VAF, n int) []string {
 		v.Followed,
 		n,
 	)
+	defer rows.Close()
 	if err != nil {
 		t.Errorf("problème d'accès à la base de données: %s", err.Error())
 		return nil
 	}
-	defer rows.Close()
 	var sirets []string
 	for rows.Next() {
 		var siret string

--- a/pkg/test/testLibrary.go
+++ b/pkg/test/testLibrary.go
@@ -251,6 +251,7 @@ func GetSiret(t *testing.T, v VAF, n int) []string {
 		t.Errorf("problème d'accès à la base de données: %s", err.Error())
 		return nil
 	}
+	defer rows.Close()
 	var sirets []string
 	for rows.Next() {
 		var siret string

--- a/pkg/wekan/cardsForUser.go
+++ b/pkg/wekan/cardsForUser.go
@@ -69,10 +69,10 @@ func selectSummariesWithSirets(
 	raisonSociale *string,
 ) (core.Summaries, error) {
 	rows, err := db.Query(ctx, SqlGetCards, roles, user.Username, sirets, zone, limit, raisonSocialeLike(raisonSociale))
-	defer rows.Close()
 	if err != nil {
 		return core.Summaries{}, err
 	}
+	defer rows.Close()
 
 	var summaries core.Summaries
 	for rows.Next() {

--- a/pkg/wekan/cardsForUser.go
+++ b/pkg/wekan/cardsForUser.go
@@ -41,10 +41,10 @@ func selectSummariesWithoutCard(
 	raisonSociale *string,
 ) (core.Summaries, error) {
 	rows, err := db.Query(ctx, SqlGetFollow, roles, user.Username, zone, sirets, raisonSocialeLike(raisonSociale))
-	defer rows.Close()
 	if err != nil {
 		return core.Summaries{}, err
 	}
+	defer rows.Close()
 
 	var summaries core.Summaries
 	for rows.Next() {
@@ -69,10 +69,10 @@ func selectSummariesWithSirets(
 	raisonSociale *string,
 ) (core.Summaries, error) {
 	rows, err := db.Query(ctx, SqlGetCards, roles, user.Username, sirets, zone, limit, raisonSocialeLike(raisonSociale))
-	defer rows.Close()
 	if err != nil {
 		return core.Summaries{}, err
 	}
+	defer rows.Close()
 
 	var summaries core.Summaries
 	for rows.Next() {

--- a/pkg/wekan/cardsForUser.go
+++ b/pkg/wekan/cardsForUser.go
@@ -41,10 +41,10 @@ func selectSummariesWithoutCard(
 	raisonSociale *string,
 ) (core.Summaries, error) {
 	rows, err := db.Query(ctx, SqlGetFollow, roles, user.Username, zone, sirets, raisonSocialeLike(raisonSociale))
+	defer rows.Close()
 	if err != nil {
 		return core.Summaries{}, err
 	}
-	defer rows.Close()
 
 	var summaries core.Summaries
 	for rows.Next() {

--- a/pkg/wekan/cardsForUser.go
+++ b/pkg/wekan/cardsForUser.go
@@ -69,10 +69,10 @@ func selectSummariesWithSirets(
 	raisonSociale *string,
 ) (core.Summaries, error) {
 	rows, err := db.Query(ctx, SqlGetCards, roles, user.Username, sirets, zone, limit, raisonSocialeLike(raisonSociale))
+	defer rows.Close()
 	if err != nil {
 		return core.Summaries{}, err
 	}
-	defer rows.Close()
 
 	var summaries core.Summaries
 	for rows.Next() {

--- a/pkg/wekan/createCard.go
+++ b/pkg/wekan/createCard.go
@@ -2,7 +2,6 @@ package wekan
 
 import (
 	"context"
-
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/signaux-faibles/libwekan"
 	"github.com/spf13/viper"
@@ -29,6 +28,7 @@ func (service wekanService) CreateCard(ctx context.Context, params core.KanbanNe
 	if err != nil {
 		return err
 	}
+
 	card, err := buildCard(board, list.ID, swimlane.ID, params.Description, params.Siret, user, etablissement, params.Labels)
 	if err != nil {
 		return err
@@ -59,8 +59,9 @@ func buildCard(
 	card.CustomFields = []libwekan.CardCustomField{activiteField, effectifField, contactField, siretField, ficheField}
 
 	labelIDs := utils.Convert(labels, labelNameToIDConvertor(configBoard))
-	card.LabelIDs = labelIDs
-
+	if labelIDs != nil {
+		card.LabelIDs = labelIDs
+	}
 	return card, nil
 }
 

--- a/pkg/wekan/etablissementData.go
+++ b/pkg/wekan/etablissementData.go
@@ -25,6 +25,7 @@ func getEtablissementDataFromDb(ctx context.Context, db *pgxpool.Pool, siret cor
 	if err != nil {
 		return etsData, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		err := rows.Scan(&etsData.Siret, &etsData.RaisonSociale, &etsData.Departement, &etsData.Region, &etsData.Effectif, &etsData.CodeActivite, &etsData.LibelleActivite)
 		if err != nil {

--- a/pkg/wekan/etablissementData.go
+++ b/pkg/wekan/etablissementData.go
@@ -21,11 +21,11 @@ func getEtablissementDataFromDb(ctx context.Context, db *pgxpool.Pool, siret cor
 	inner join regions r on r.id = d.id_region
 	where s.siret = $1`
 	rows, err := db.Query(ctx, sql, siret)
+	defer rows.Close()
 	var etsData core.EtablissementData
 	if err != nil {
 		return etsData, err
 	}
-	defer rows.Close()
 	for rows.Next() {
 		err := rows.Scan(&etsData.Siret, &etsData.RaisonSociale, &etsData.Departement, &etsData.Region, &etsData.Effectif, &etsData.CodeActivite, &etsData.LibelleActivite)
 		if err != nil {

--- a/pkg/wekan/exports.go
+++ b/pkg/wekan/exports.go
@@ -168,10 +168,10 @@ func selectKanbanDBExportsWithSirets(ctx context.Context,
 	zone []string,
 	raisonSociale *string) (core.KanbanDBExports, error) {
 	rows, err := db.Query(ctx, sqlDbExport, roles, username, sirets, zone, raisonSocialeLike(raisonSociale))
-	defer rows.Close()
 	if err != nil {
 		return core.KanbanDBExports{}, err
 	}
+	defer rows.Close()
 
 	var kanbanDBExports core.KanbanDBExports
 	for rows.Next() {
@@ -202,10 +202,10 @@ func selectKanbanDBExportsWithoutCard(
 	raisonSociale *string,
 ) (core.KanbanDBExports, error) {
 	rows, err := db.Query(ctx, sqlDbExportWithoutCards, roles, user.Username, sirets, zone, raisonSocialeLike(raisonSociale))
-	defer rows.Close()
 	if err != nil {
 		return core.KanbanDBExports{}, err
 	}
+	defer rows.Close()
 
 	var kanbanDBExports core.KanbanDBExports
 	for rows.Next() {

--- a/pkg/wekan/exports.go
+++ b/pkg/wekan/exports.go
@@ -168,10 +168,10 @@ func selectKanbanDBExportsWithSirets(ctx context.Context,
 	zone []string,
 	raisonSociale *string) (core.KanbanDBExports, error) {
 	rows, err := db.Query(ctx, sqlDbExport, roles, username, sirets, zone, raisonSocialeLike(raisonSociale))
+	defer rows.Close()
 	if err != nil {
 		return core.KanbanDBExports{}, err
 	}
-	defer rows.Close()
 
 	var kanbanDBExports core.KanbanDBExports
 	for rows.Next() {

--- a/pkg/wekan/exports.go
+++ b/pkg/wekan/exports.go
@@ -168,10 +168,10 @@ func selectKanbanDBExportsWithSirets(ctx context.Context,
 	zone []string,
 	raisonSociale *string) (core.KanbanDBExports, error) {
 	rows, err := db.Query(ctx, sqlDbExport, roles, username, sirets, zone, raisonSocialeLike(raisonSociale))
-	defer rows.Close()
 	if err != nil {
 		return core.KanbanDBExports{}, err
 	}
+	defer rows.Close()
 
 	var kanbanDBExports core.KanbanDBExports
 	for rows.Next() {
@@ -206,6 +206,7 @@ func selectKanbanDBExportsWithoutCard(
 	if err != nil {
 		return core.KanbanDBExports{}, err
 	}
+
 	var kanbanDBExports core.KanbanDBExports
 	for rows.Next() {
 		var s []interface{}

--- a/pkg/wekan/sql.go
+++ b/pkg/wekan/sql.go
@@ -99,5 +99,5 @@ coalesce(v.periode_urssaf, '0001-01-01'), v.last_procol, coalesce(v.date_last_pr
 coalesce(f.comment, ''), (permissions($1, v.roles, v.first_list_entreprise, v.code_departement, f.siret is not null)).in_zone
 from v_summaries v
 inner join etablissement_follow f on f.siret = v.siret and f.username = $2 and active
-where (v.code_departement = any($4) or coalesce($4, '{}') = '{}') and v.siret != any($3) and (v.raison_sociale ilike $5 or $5 is null)
+where (v.code_departement = any($4) or coalesce($4, '{}') = '{}') and (not (v.siret = any($3)) or $3 is null) and (v.raison_sociale ilike $5 or $5 is null)
 order by f.id, v.siret`


### PR DESCRIPTION
Normalement, pgx ferme les curseurs automatiquement lorsqu'ils ont été entièrement consommés, mais on est pas à l'abris qu'une méthode laisse parfois un curseur pas totalement consommé en souffrance, ce qui peut mener à terme à un blocage de l'application par une occupation artificielle de toutes les connexions du pool.