### PR TITLE
Feature/improve prediction list filters

### DIFF
--- a/migrations/240516_0_nouvel_index_v_summaries.sql
+++ b/migrations/240516_0_nouvel_index_v_summaries.sql
@@ -1,0 +1,22 @@
+drop index idx_v_summaries_score;
+
+create index if not exists idx_v_summaries_score on
+public.v_summaries
+	using btree (
+  valeur_score desc, 
+  siret, 
+  siege,
+  effectif, 
+  effectif_entreprise, 
+  code_departement, 
+  last_procol, 
+  chiffre_affaire, 
+  etat_administratif, 
+  first_alert, 
+  first_list_entreprise, 
+  first_red_list_entreprise, 
+  has_delai, 
+  date_creation_entreprise,
+  code_activite)
+where
+(alert <> 'Pas d''alerte'::text)

--- a/pkg/core/follow.go
+++ b/pkg/core/follow.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"datapi/pkg/db"
 	"datapi/pkg/utils"
-	"github.com/signaux-faibles/libwekan"
 	"net/http"
 	"time"
+
+	"github.com/signaux-faibles/libwekan"
 
 	"github.com/gin-gonic/gin"
 )
@@ -196,7 +197,7 @@ func (f *Follow) list(roles Scope) (Follows, utils.Jerror) {
 
 	params := summaryParams{roles, nil, nil, &liste[0].ID, false, nil,
 		&True, &True, *f.Username, false, "follow", &False, nil,
-		nil, &True, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil}
+		nil, &True, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil}
 
 	sms, err := getSummaries(params)
 	if err != nil {

--- a/pkg/core/score.go
+++ b/pkg/core/score.go
@@ -33,6 +33,7 @@ type paramsListeScores struct {
 	Filter                string   `json:"filter"`
 	ExcludeSecteursCovid  []string `json:"excludeSecteursCovid"`
 	EtatAdministratif     *string  `json:"etatAdministratif"`
+	CreationDateThreshold *string  `json:"creationDateThreshold"`
 	FirstAlert            *bool    `json:"firstAlert"`
 	HasntDelai            *bool    `json:"hasntDelai"`
 }
@@ -217,7 +218,7 @@ func (liste *Liste) getScores(roles Scope, page int, limit *int, username string
 		liste.Query.IgnoreZone, username, liste.Query.SiegeUniquement, "score", &True, liste.Query.EtatsProcol,
 		liste.Query.Departements, suivi, liste.Query.EffectifMin, liste.Query.EffectifMax, nil, liste.Query.Activites,
 		liste.Query.EffectifMinEntreprise, liste.Query.EffectifMaxEntreprise, liste.Query.CaMin, liste.Query.CaMax,
-		liste.Query.ExcludeSecteursCovid, liste.Query.EtatAdministratif, liste.Query.FirstAlert, liste.Query.HasntDelai,
+		liste.Query.ExcludeSecteursCovid, liste.Query.EtatAdministratif, liste.Query.CreationDateThreshold, liste.Query.FirstAlert, liste.Query.HasntDelai,
 	}
 	summaries, err := getSummaries(params)
 	if err != nil {

--- a/pkg/core/search.go
+++ b/pkg/core/search.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"datapi/pkg/utils"
+
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/viper"
 )
@@ -88,7 +89,7 @@ func searchEtablissement(params searchParams) (searchResult, utils.Jerror) {
 		zoneGeo, &limit, &offset, &liste[0].ID, false, &params.Search, &params.IgnoreRoles, &params.IgnoreZone,
 		params.username, params.SiegeUniquement, "raison_sociale", &False, nil, params.Departements, nil,
 		params.EffectifMin, nil, nil, params.Activites, params.EffectifMinEntreprise, params.EffectifMaxEntreprise,
-		params.CaMin, params.CaMax, params.ExcludeSecteursCovid, params.EtatAdministratif, nil, nil,
+		params.CaMin, params.CaMax, params.ExcludeSecteursCovid, params.EtatAdministratif, nil, nil, nil,
 	}
 	summaries, err := getSummaries(summaryparams)
 	if err != nil {

--- a/pkg/core/sql.go
+++ b/pkg/core/sql.go
@@ -1,5 +1,14 @@
 package core
 
+// Liste de codes NAF à exclure pour réduire la taille des listes.
+const ExcludedNafCodes = `AND s.code_activite NOT IN (
+  '8411Z', '8412Z', '8421Z', '8422Z', '8423Z', '8424Z', '8425Z', '8413Z', '8430A', '8430B', '8430C',
+  '9491Z', '9492Z', '9420Z', '9411Z', '9412Z',
+  '6411Z', '6419Z', '6430Z', '6491Z', '6492Z', '6499Z', '6511Z', '6512Z', '6520Z', '6530Z', '6611Z', '6612Z', '6619A', '6619B', '6621Z', '6622Z', '6629Z', '6630Z',
+  '8510Z', '8520Z', '8531Z', '8532Z', '8541Z', '8542Z',
+  '8810A', '8810B', '8810C', '8891A', '8891B', '8899B'
+)`
+
 func (p summaryParams) toSQLCurrentScoreParams() []interface{} {
 	var expressionSiret *string
 	var expressionRaisonSociale *string
@@ -93,6 +102,7 @@ from v_summaries s
   and (s.first_alert = $22 or $22 is null)
   and (not (s.has_delai = $23) or $23 is null)
   and (s.date_creation_entreprise <= $24 or $24 is null)
+  ` + ExcludedNafCodes + `
 order by s.alert, s.valeur_score desc, s.siret
 limit $2 offset $3`
 
@@ -191,5 +201,6 @@ var sqlScore = `select
   and (not (s.has_delai = $23) or $23 is null)
   and (s.date_creation_entreprise <= $24 or $24 is null)
   and ((s.first_list_etablissement = $25 or s.first_red_list_etablissement = $25) and $22 or $22 is null)
+  ` + ExcludedNafCodes + `
   order by sc.alert, sc.score desc, s.siret
   limit $2 offset $3`

--- a/pkg/core/sql.go
+++ b/pkg/core/sql.go
@@ -34,6 +34,7 @@ func (p summaryParams) toSQLCurrentScoreParams() []interface{} {
 		p.etatAdministratif,
 		p.firstAlert,
 		p.hasntDelai,
+		p.creationDateThreshold,
 	}
 }
 
@@ -91,6 +92,7 @@ from v_summaries s
   and (s.etat_administratif = $21 or $21 is null)
   and (s.first_alert = $22 or $22 is null)
   and (not (s.has_delai = $23) or $23 is null)
+  and (s.date_creation_entreprise <= $24 or $24 is null)
 order by s.alert, s.valeur_score desc, s.siret
 limit $2 offset $3`
 
@@ -128,7 +130,7 @@ func (p summaryParams) toSQLScoreParams() []interface{} {
 		p.etatAdministratif,
 		p.firstAlert,
 		p.hasntDelai,
-
+		p.creationDateThreshold,
 		// insert new argument before and manually update index of libelleListe
 		p.libelleListe,
 	}
@@ -187,6 +189,7 @@ var sqlScore = `select
   and (n.code_n1 = any($15) or $15 is null)
   and (s.etat_administratif = $21 or $21 is null)
   and (not (s.has_delai = $23) or $23 is null)
-  and ((s.first_list_etablissement = $24 or s.first_red_list_etablissement = $24) and $22 or $22 is null)
+  and (s.date_creation_entreprise <= $24 or $24 is null)
+  and ((s.first_list_etablissement = $25 or s.first_red_list_etablissement = $25) and $22 or $22 is null)
   order by sc.alert, sc.score desc, s.siret
   limit $2 offset $3`

--- a/pkg/core/summary.go
+++ b/pkg/core/summary.go
@@ -154,6 +154,7 @@ type summaryParams struct {
 	caMax                 *int
 	excludeSecteursCovid  []string
 	etatAdministratif     *string
+	creationDateThreshold *string
 	firstAlert            *bool
 	hasntDelai            *bool
 }


### PR DESCRIPTION
Exclude companies that were established less than two years ago and omit specific NAF codes to shorten the prediction list.
Update score index in v_summaries table accordingly.