### PR TITLE
Added a way to list routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@ postgres = "host=localhost port=5432 user=postgres password=toto dbname=postgres
 [stats]
 db_url = "postgres://postgres:toto@localhost:5432/datapilogs"
 ```
-
 -   Exécuter le binaire
+
+
+  Il est possible de lister les routes en exécutant la commande suivante (Il faut avoir buildé le binaire avec `go build`):
+  ```bash
+  ./datapi --list-routes=true
+  ```
 
 ## Conteneur
 -  `cd build-container`

--- a/pkg/core/datapi.go
+++ b/pkg/core/datapi.go
@@ -2,6 +2,7 @@
 package core
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"log/slog"
@@ -121,9 +122,18 @@ func AddEndpoint(router *gin.Engine, path string, endpoint Endpoint, handlers ..
 func StartAPI(router *gin.Engine) {
 	addr := viper.GetString("bind")
 	log.Print("Running API on " + addr)
-	err := router.Run(addr)
-	if err != nil {
-		fmt.Println(err.Error())
+
+	listOnly := flag.Bool("list-routes", false, "List all registered routes and exit")
+	flag.Parse()
+
+	if *listOnly {
+		utils.ListRoutes(router)
+	} else {
+		err := router.Run(addr)
+
+		if err != nil {
+			fmt.Println(err.Error())
+		}
 	}
 }
 

--- a/pkg/utils/routes.go
+++ b/pkg/utils/routes.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ListRoutes prints all registered routes in the Gin application, grouped by the first segment of the route
+func ListRoutes(router *gin.Engine) {
+	routeMap := make(map[string][]string)
+
+	for _, route := range router.Routes() {
+		segments := strings.Split(route.Path, "/")
+		if len(segments) > 1 {
+			firstSegment := segments[1]
+			key := "/" + firstSegment
+			routeMap[key] = append(routeMap[key], fmt.Sprintf("%s -> %s", route.Path, route.Handler))
+		}
+	}
+
+	firstSegments := make([]string, 0, len(routeMap))
+	for k := range routeMap {
+		firstSegments = append(firstSegments, k)
+	}
+	sort.Strings(firstSegments)
+
+	for _, fs := range firstSegments {
+		fmt.Printf("%s:\n", fs)
+		for _, route := range routeMap[fs] {
+			fmt.Println("  " + route)
+		}
+		fmt.Println()
+	}
+}


### PR DESCRIPTION
Added a function in utils which allows the user to list all the application endpoints configured in the Gin router.